### PR TITLE
Refetch NFT After Action

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
+
 const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT;
 
 const client = new ApolloClient({
@@ -6,7 +7,7 @@ const client = new ApolloClient({
     cache: new InMemoryCache({
         typePolicies: {
             Marketplace: {
-                keyFields: ['subdomain'],
+                keyFields: ['ownerAddress'],
             },
             Nft: {
                 keyFields: ['address']

--- a/src/components/CancelOfferForm/index.tsx
+++ b/src/components/CancelOfferForm/index.tsx
@@ -1,4 +1,5 @@
 import { useForm } from 'react-hook-form'
+import { OperationVariables, ApolloQueryResult } from '@apollo/client'
 import Button, { ButtonType } from './../../components/Button'
 import { toast } from 'react-toastify'
 import {
@@ -7,13 +8,14 @@ import {
   SYSVAR_INSTRUCTIONS_PUBKEY,
 } from '@solana/web3.js'
 import { AuctionHouseProgram } from '@metaplex-foundation/mpl-auction-house'
-import { Marketplace, Nft, Listing, Offer } from '../../types'
+import { Marketplace, Nft, Offer } from '../../types'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 
 interface CancelOfferFormProps {
-  offer: Offer
-  nft?: Nft
-  marketplace: Marketplace
+  offer: Offer;
+  nft?: Nft;
+  marketplace: Marketplace;
+  refetch: (variables?: Partial<OperationVariables> | undefined) => Promise<ApolloQueryResult<_>>;
 }
 
 
@@ -22,7 +24,7 @@ const {
     createCancelBidReceiptInstruction
   } = AuctionHouseProgram.instructions
 
-const CancelOfferForm = ({ offer, nft, marketplace }: CancelOfferFormProps) => {
+const CancelOfferForm = ({ offer, nft, marketplace, refetch }: CancelOfferFormProps) => {
   const { publicKey, signTransaction } = useWallet()
   const { connection } = useConnection()
   const cancelOfferForm = useForm()
@@ -106,12 +108,14 @@ const CancelOfferForm = ({ offer, nft, marketplace }: CancelOfferFormProps) => {
 
     try {
       toast('Sending the transaction to Solana.')
-      
+
       signature = await connection.sendRawTransaction(signed.serialize())
 
       await connection.confirmTransaction(signature, 'processed')
 
       toast('The transaction was confirmed.')
+
+      await refetch();
     } catch {
       toast.error(
         <>

--- a/src/components/CancelOfferForm/index.tsx
+++ b/src/components/CancelOfferForm/index.tsx
@@ -12,7 +12,7 @@ import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 
 interface CancelOfferFormProps {
   offer: Offer
-  nft: Nft
+  nft?: Nft
   marketplace: Marketplace
 }
 
@@ -28,7 +28,7 @@ const CancelOfferForm = ({ offer, nft, marketplace }: CancelOfferFormProps) => {
   const cancelOfferForm = useForm()
 
   const cancelOfferTransaction = async () => {
-    if (!publicKey || !signTransaction || !offer) {
+    if (!publicKey || !signTransaction || !offer || !nft) {
       return
     }
     const auctionHouse = new PublicKey(marketplace.auctionHouse.address)
@@ -105,9 +105,9 @@ const CancelOfferForm = ({ offer, nft, marketplace }: CancelOfferFormProps) => {
     let signature: string  = ""
 
     try {
-      signature = await connection.sendRawTransaction(signed.serialize())
-
       toast('Sending the transaction to Solana.')
+      
+      signature = await connection.sendRawTransaction(signed.serialize())
 
       await connection.confirmTransaction(signature, 'processed')
 

--- a/src/components/Offer/index.tsx
+++ b/src/components/Offer/index.tsx
@@ -24,7 +24,7 @@ interface OfferForm {
 }
 
 interface OfferProps {
-  nft: Nft
+  nft?: Nft;
   marketplace: Marketplace
 }
 
@@ -35,7 +35,7 @@ const Offer = ({ nft, marketplace }: OfferProps) => {
   const router = useRouter()
 
   const placeOfferTransaction = async ({ amount }: OfferForm) => {
-    if (!publicKey || !signTransaction) {
+    if (!publicKey || !signTransaction || !nft) {
       return
     }
 
@@ -166,7 +166,7 @@ const Offer = ({ nft, marketplace }: OfferProps) => {
         />
       </div>
       <div className='grid grid-cols-2 gap-4'>
-        <Link to={`/nfts/${nft.address}`}>
+        <Link to={`/nfts/${nft?.address}`}>
           <Button type={ButtonType.Secondary}>
           Cancel
           </Button>

--- a/src/components/Offer/index.tsx
+++ b/src/components/Offer/index.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 import { useRouter } from 'next/router'
 import { AuctionHouseProgram } from '@metaplex-foundation/mpl-auction-house'
+import { OperationVariables, ApolloQueryResult } from '@apollo/client'
 import { MetadataProgram } from '@metaplex-foundation/mpl-token-metadata'
 import {
   Transaction,
@@ -26,9 +27,10 @@ interface OfferForm {
 interface OfferProps {
   nft?: Nft;
   marketplace: Marketplace
+  refetch: (variables?: Partial<OperationVariables> | undefined) => Promise<ApolloQueryResult<_>>
 }
 
-const Offer = ({ nft, marketplace }: OfferProps) => {
+const Offer = ({ nft, marketplace, refetch }: OfferProps) => {
   const { handleSubmit, register, formState: { isSubmitting } } = useForm<OfferForm>({})
   const { publicKey, signTransaction } = useWallet()
   const { connection } = useConnection()
@@ -135,11 +137,13 @@ const Offer = ({ nft, marketplace }: OfferProps) => {
     let signature: string;
 
     try {
-      signature = await connection.sendRawTransaction(signed.serialize());
-
       toast('Sending the transaction to Solana.');
 
-      await connection.confirmTransaction(signature, 'processed');
+      signature = await connection.sendRawTransaction(signed.serialize());
+
+      await connection.confirmTransaction(signature, 'confirmed');
+
+      await refetch();
 
       toast('The transaction was confirmed.');
     } catch {

--- a/src/components/SellNft/index.tsx
+++ b/src/components/SellNft/index.tsx
@@ -25,7 +25,7 @@ interface SellNftForm {
 }
 
 interface SellNftProps {
-  nft: Nft
+  nft?: Nft
   marketplace: Marketplace
 }
 
@@ -36,6 +36,10 @@ const SellNft = ({ nft, marketplace }: SellNftProps) => {
   const router = useRouter()
 
   const sellNftTransaction = async ({ amount }: SellNftForm) => {
+    if (!publicKey || !signTransaction || !nft) {
+      return
+    }
+
     const buyerPrice = Number(amount) * LAMPORTS_PER_SOL
     const auctionHouse = new PublicKey(marketplace.auctionHouse.address)
     const authority = new PublicKey(marketplace.auctionHouse.authority)
@@ -44,10 +48,6 @@ const SellNft = ({ nft, marketplace }: SellNftProps) => {
     )
     const treasuryMint = new PublicKey(marketplace.auctionHouse.treasuryMint)
     const tokenMint = new PublicKey(nft.mintAddress)
-
-    if (!publicKey || !signTransaction) {
-      return
-    }
 
     const [
       associatedTokenAccount,
@@ -232,7 +232,7 @@ const SellNft = ({ nft, marketplace }: SellNftProps) => {
         />
       </div>
       <div className='grid flex-grow grid-cols-2 gap-4'>
-        <Link to={`/nfts/${nft.address}`}>
+        <Link to={`/nfts/${nft?.address}`}>
           <Button type={ButtonType.Secondary}>
             Cancel
           </Button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,9 +42,8 @@ const GET_NFTS = gql`
 export async function getServerSideProps({ req }: NextPageContext) {
   const subdomain = req?.headers['x-holaplex-subdomain'];
 
-  const {
-    data: { marketplace },
-  } = await client.query<GetMarketplace>({
+  const response = await client.query<GetMarketplace>({
+    fetchPolicy: 'no-cache',
     query: gql`
       query GetMarketplace($subdomain: String!) {
         marketplace(subdomain: $subdomain) {
@@ -80,6 +79,8 @@ export async function getServerSideProps({ req }: NextPageContext) {
       subdomain: (subdomain || SUBDOMAIN),
     },
   })
+
+  const { data: { marketplace } } = response;
 
   if (isNil(marketplace)) {
     return {

--- a/src/pages/nfts/[...address].tsx
+++ b/src/pages/nfts/[...address].tsx
@@ -5,15 +5,20 @@ import {
   isNil,
   pipe,
   ifElse,
+  or,
   always,
   equals,
   length,
   find,
   prop,
   filter,
+  and,
+  not,
 } from 'ramda'
-import client from '../../client'
-import { useRouter } from 'next/router'
+import cx from 'classnames';
+import client from '../../client';
+import { useRouter } from 'next/router';
+import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom'
 import Button, { ButtonType } from './../../components/Button';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui'
@@ -53,39 +58,9 @@ const {
 
 const pickAuctionHouse = prop('auctionHouse');
 
-export async function getServerSideProps({ req, query }: NextPageContext) {
-  const subdomain = req?.headers['x-holaplex-subdomain'];
-
-  const {
-    data: { marketplace, nft },
-  } = await client.query<GetNftPage>({
-    query: gql`
-      query GetNftPage($subdomain: String!, $address: String!) {
-        marketplace(subdomain: $subdomain) {
-          subdomain
-          name
-          description
-          logoUrl
-          bannerUrl
-          ownerAddress
-          auctionHouse {
-            address
-            treasuryMint
-            auctionHouseTreasury
-            treasuryWithdrawalDestination
-            feeWithdrawalDestination
-            authority
-            creator
-            auctionHouseFeeAccount
-            bump
-            treasuryBump
-            feePayerBump
-            sellerFeeBasisPoints
-            requiresSignOff
-            canChangeSalePrice
-          }
-        }
-        nft(address: $address) {
+const GET_NFT = gql`
+  query GetNft($address: String!) {
+    nft(address: $address) {
           name
           address
           image
@@ -125,6 +100,48 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
             canceledAt
           }
         }
+  }
+`
+
+export async function getServerSideProps({ req, query }: NextPageContext) {
+  const subdomain = req?.headers['x-holaplex-subdomain'];
+
+  const {
+    data: { marketplace, nft },
+  } = await client.query<GetNftPage>({
+    fetchPolicy: 'no-cache',
+    query: gql`
+      query GetNftPage($subdomain: String!, $address: String!) {
+        marketplace(subdomain: $subdomain) {
+          subdomain
+          name
+          description
+          logoUrl
+          bannerUrl
+          ownerAddress
+          auctionHouse {
+            address
+            treasuryMint
+            auctionHouseTreasury
+            treasuryWithdrawalDestination
+            feeWithdrawalDestination
+            authority
+            creator
+            auctionHouseFeeAccount
+            bump
+            treasuryBump
+            feePayerBump
+            sellerFeeBasisPoints
+            requiresSignOff
+            canChangeSalePrice
+          }
+        }
+        nft(address: $address) {
+          address
+          creators {
+            address
+          }
+        }
       }
     `,
     variables: {
@@ -133,7 +150,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
     },
   })
 
-  if (isNil(marketplace)) {
+  if (or(isNil(marketplace), isNil(nft))) {
     return {
       notFound: true,
     }
@@ -142,22 +159,24 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
   return {
     props: {
       marketplace,
-      nft,
     },
   }
 }
 
 interface GetNftPage {
-  marketplace: Marketplace | null
-  nft: Nft | null
+  marketplace: Marketplace | null;
+  nft: Nft | null;
 }
 
 interface NftPageProps extends AppProps {
   marketplace: Marketplace
-  nft: Nft
 }
 
-const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
+interface GetNftData {
+  nft: Nft;
+}
+
+const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
   const { publicKey, signTransaction } = useWallet();
   const { connection } = useConnection();
   const router = useRouter();
@@ -165,22 +184,27 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
   const cancelOfferForm = useForm();
   const buyNowForm = useForm();
 
+  const { data, loading } = useQuery<GetNftData>(GET_NFT, {
+    variables: {
+      address: (router.query?.address || [])[0],
+    },
+  });
+
   const isMarketplaceAuctionHouse = equals(marketplace.auctionHouse.address);
-  const pickAuctionHouse = prop('auctionHouse');
-  const isOwner = equals(nft.owner.address, publicKey?.toBase58());
+  const isOwner = equals(data?.nft.owner.address, publicKey?.toBase58());
   const listing = find<Listing>(
     pipe(pickAuctionHouse, isMarketplaceAuctionHouse)
-  )(nft.listings);
+  )(data?.nft.listings || []);
   const offers = filter<Offer>(
     pipe(pickAuctionHouse, isMarketplaceAuctionHouse)
-  )(nft.offers);
+  )(data?.nft.offers || []);
 
   const offer = find<Offer>(
     pipe(prop('buyer'), equals(publicKey?.toBase58()))
   )(nft.offers);
 
   const buyNftTransaction = async () => {
-    if (!publicKey || !signTransaction || !listing || isOwner) {
+    if (!publicKey || !signTransaction || !listing || isOwner || !data) {
       return
     }
 
@@ -191,7 +215,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
     )
     const treasuryMint = new PublicKey(marketplace.auctionHouse.treasuryMint)
     const seller = new PublicKey(listing.seller)
-    const tokenMint = new PublicKey(nft.mintAddress)
+    const tokenMint = new PublicKey(data?.nft.mintAddress)
     const auctionHouseTreasury = new PublicKey(
       marketplace.auctionHouse.auctionHouseTreasury
     )
@@ -201,7 +225,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
       tokenAccount,
     ] = await AuctionHouseProgram.findAssociatedTokenAccountAddress(
       tokenMint,
-      new PublicKey(nft.owner.address)
+      new PublicKey(data?.nft.owner.address)
     )
     const [metadata] = await MetadataProgram.findMetadataAccount(tokenMint)
 
@@ -390,7 +414,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
   }
 
   const cancelListingTransaction = async () => {
-    if (!publicKey || !signTransaction || !listing || !isOwner) {
+    if (!publicKey || !signTransaction || !listing || !isOwner || !data) {
       return
     }
 
@@ -399,14 +423,14 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
     const auctionHouseFeeAccount = new PublicKey(
       marketplace.auctionHouse.auctionHouseFeeAccount
     )
-    const tokenMint = new PublicKey(nft.mintAddress)
+    const tokenMint = new PublicKey(data?.nft.mintAddress)
     const treasuryMint = new PublicKey(marketplace.auctionHouse.treasuryMint)
     const receipt = new PublicKey(listing.address)
     const [
       tokenAccount,
     ] = await AuctionHouseProgram.findAssociatedTokenAccountAddress(
       tokenMint,
-      new PublicKey(nft.owner.address)
+      new PublicKey(data?.nft.owner.address)
     )
 
     const [tradeState] = await AuctionHouseProgram.findTradeStateAddress(
@@ -480,7 +504,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
   }
 
   const cancelOfferTransaction = (address: string, price: number) => async () => {
-    if (!publicKey || !signTransaction || !offer) { 
+    if (!publicKey || !signTransaction || !offer) {
       return
     }
     const auctionHouse = new PublicKey(marketplace.auctionHouse.address)
@@ -585,47 +609,83 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
         <div className='grid items-start grid-cols-1 gap-6 mt-12 mb-10 lg:grid-cols-2'>
           <div className='block mb-4 lg:mb-0 lg:flex lg:items-center lg:justify-center '>
             <div className='block mb-6 lg:hidden'>
-              <p className='mb-4 text-2xl lg:text-4xl md:text-3xl'>
-                <b>{nft.name}</b>
-              </p>
-              <p className='text-lg'>{nft.description}</p>
+              {loading ? (
+                <div className="w-full h-32 bg-gray-800 rounded-lg" />
+              ) : (
+                <>
+                  <h1 className='mb-4 text-2xl'>{data?.nft.name}</h1>
+                  <p className='text-lg'>{data?.nft.description}</p>
+                </>
+              )}
             </div>
-            <img
-              src={nft.image}
-              className='block h-auto max-w-full border-none rounded-lg shadow'
-            />
+            {loading ? (
+              <div className='aspect-square border-none bg-gray-800 w-full rounded-lg' />
+            ) : (
+              <img
+                src={data?.nft.image}
+                className='block h-auto max-w-full border-none rounded-lg shadow'
+              />
+            )}
           </div>
           <div>
             <div className='hidden mb-8 lg:block'>
-              <p className='mb-4 text-2xl lg:text-4xl md:text-3xl'>
-                <b>{nft.name}</b>
-              </p>
-              <p className='text-lg'>{nft.description}</p>
+              {loading ? (
+                <div className="w-full h-32 bg-gray-800 rounded-lg" />
+              ) : (
+                <>
+                  <h1 className='mb-4 text-2xl lg:text-4xl md:text-3xl'>{data?.nft.name}</h1>
+                  <p className='text-lg'>{data?.nft.description}</p>
+                </>
+              )}
             </div>
             <div className='flex-1 mb-8'>
               <div className='mb-1 label'>
-                {ifElse(
-                  pipe(length, equals(1)),
-                  always('CREATOR'),
-                  always('CREATORS')
-                )(nft.creators)}
+                {loading ? (
+                  <div className="w-14 h-4 bg-gray-800 rounded" />
+                ) : (
+                  ifElse(
+                    pipe(length, equals(1)),
+                    always('CREATOR'),
+                    always('CREATORS')
+                  )(data?.nft.creators || "")
+                )}
               </div>
               <ul>
-                {nft.creators.map(({ address }) => (
-                  <li key={address}>
-                    <a
-                      href={`https://holaplex.com/profiles/${address}`}
-                      rel='noreferrer'
-                      target='_blank'
-                    >
-                      <Avatar name={truncateAddress(address)} />
-                    </a>
+                {loading ? (
+                  <li>
+                    <div className="w-20 h-6 bg-gray-800 rounded" />
                   </li>
-                ))}
+                ) : (
+                  data?.nft.creators.map(({ address }) => (
+                    <li key={address}>
+                      <a
+                        href={`https://holaplex.com/profiles/${address}`}
+                        rel='noreferrer'
+                        target='_blank'
+                      >
+                        <Avatar name={truncateAddress(address)} />
+                      </a>
+                    </li>
+                  ))
+                )}
               </ul>
             </div>
-            <div className='w-full p-6 mt-8 bg-gray-800 rounded-lg'>
-              <div className='flex mb-6'>
+            <div className={
+              cx(
+                'w-full p-6 mt-8 bg-gray-800 rounded-lg',
+                {
+                  'h-44': loading,
+                }
+              )
+            }>
+              <div className={
+                cx(
+                  'flex mb-6',
+                  {
+                    'hidden': loading,
+                  }
+                )
+              }>
                 {listing && (
                   <div className='flex-1'>
                     <div className='label'>PRICE</div>
@@ -637,23 +697,23 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
                 <div className='flex-1'>
                   <div className='mb-1 label'>OWNER</div>
                   <a
-                    href={`https://holaplex.com/profiles/${nft.owner.address}`}
+                    href={`https://holaplex.com/profiles/${data?.nft.owner.address}`}
                     rel='noreferrer'
                     target='_blank'
                   >
-                    <Avatar name={truncateAddress(nft.owner.address)} />
+                    <Avatar name={truncateAddress(data?.nft.owner.address || "")} />
                   </a>
                 </div>
               </div>
-              <div className='flex gap-4 overflow-visible'>
+              <div className={cx('flex gap-4', { hidden: loading })}>
                 <Routes>
                   <Route
-                    path={`/nfts/${nft.address}`}
+                    path={`/nfts/${data?.nft.address}`}
                     element={
                       <>
                         {!isOwner && !offer && (
                           <Link
-                            to={`/nfts/${nft.address}/offers/new`}
+                            to={`/nfts/${data?.nft.address}/offers/new`}
                             className='flex-1'
                           >
                             <Button type={ButtonType.Secondary}>
@@ -663,7 +723,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
                         )}
                         {isOwner && !listing && (
                           <Link
-                            to={`/nfts/${nft.address}/listings/new`}
+                            to={`/nfts/${data?.nft.address}/listings/new`}
                             className='flex-1'
                           >
                             <Button>
@@ -681,7 +741,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
                             </Button>
                           </form>
                         )}
-                        {listing && isOwner &&  (
+                        {listing && isOwner && (
                           <form className="flex-1" onSubmit={cancelListingForm.handleSubmit(cancelListingTransaction)}>
                             <Button
                               loading={cancelListingForm.formState.isSubmitting}
@@ -696,38 +756,48 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
                     }
                   />
                   <Route
-                    path={`/nfts/${nft.address}/offers/new`}
-                    element={<OfferPage nft={nft} marketplace={marketplace} />}
+                    path={`/nfts/${data?.nft.address}/offers/new`}
+                    element={<OfferPage nft={data?.nft} marketplace={marketplace} />}
                   />
                   <Route
-                    path={`/nfts/${nft.address}/listings/new`}
+                    path={`/nfts/${data?.nft.address}/listings/new`}
                     element={
-                      <SellNftPage nft={nft} marketplace={marketplace} />
+                      <SellNftPage nft={data?.nft} marketplace={marketplace} />
                     }
                   />
                 </Routes>
               </div>
             </div>
             <div className='grid grid-cols-2 gap-6 mt-8'>
-              {nft.attributes.map(a => (
-                <div
-                  key={a.traitType}
-                  className='p-3 border border-gray-700 rounded'
-                >
-                  <p className='uppercase label'>{a.traitType}</p>
-                  <p className='truncate text-ellipsis' title={a.value}>
-                    {a.value}
-                  </p>
-                </div>
-              ))}
+              {loading ? (
+                <>
+                  <div className="h-16 rounded bg-gray-800" />
+                  <div className="h-16 rounded bg-gray-800" />
+                  <div className="h-16 rounded bg-gray-800" />
+                  <div className="h-16 rounded bg-gray-800" />
+                </>
+              ) : (
+                data?.nft.attributes.map(a => (
+                  <div
+                    key={a.traitType}
+                    className='p-3 border border-gray-700 rounded'
+                  >
+                    <p className='uppercase label'>{a.traitType}</p>
+                    <p className='truncate text-ellipsis' title={a.value}>
+                      {a.value}
+                    </p>
+                  </div>
+                ))
+              )}
+
             </div>
           </div>
-        </div>
+        </div >
         <div className='flex justify-between px-4 mt-10 mb-10 text-sm sm:text-base md:text-lg '>
           <div className='w-full'>
             <h2 className='mb-4 text-xl md:text-2xl text-bold'>Offers</h2>
             {ifElse(
-              pipe(length, equals(0)),
+              (offers: Offer[]) => and(pipe(length, equals(0))(offers), not(loading)),
               always(
                 <div className='w-full p-10 text-center border border-gray-800 rounded-lg'>
                   <h3>No offers found</h3>
@@ -744,33 +814,41 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, nft }) => {
                     <span className='label'>WHEN</span>
                     <span className='label'>ACTION</span>
                   </header>
-                  {offers.map((offer: Offer) => (
-                    <article
-                      key={offer.address}
-                      className='grid grid-cols-4 p-4 mb-4 border border-gray-700 rounded'
-                    >
-                      <div>
-                        <a
-                          href={`https://holaplex.com/profiles/${offer.buyer}`}
-                          rel='nofollower'
-                        >
-                          {truncateAddress(offer.buyer)}
-                          {offer && <span className="px-3 py-1 ml-1 text-xs text-black bg-white rounded-full ">You</span>}
-                        </a>
-                      </div>
-                      <div>
-                        <span className='sol-amount'>{toSOL(offer.price)}</span>
-                      </div>
-                      <div>{format(offer.createdAt, 'en_US')}</div>
-                      <CancelOfferForm nft={nft} marketplace={marketplace} offer={offer}/>
-                    </article>
-                  ))}
+                  {loading ? (
+                    <>
+                      <article className="bg-gray-800 mb-4 h-16 rounded" />
+                      <article className="bg-gray-800 mb-4 h-16 rounded" />
+                      <article className="bg-gray-800 mb-4 h-16 rounded" />
+                    </>
+                  ) : (
+                    offers.map((offer: Offer) => (
+                      <article
+                        key={offer.address}
+                        className='grid grid-cols-4 p-4 mb-4 border border-gray-700 rounded'
+                      >
+                        <div>
+                          <a
+                            href={`https://holaplex.com/profiles/${offer.buyer}`}
+                            rel='nofollower'
+                          >
+                            {truncateAddress(offer.buyer)}
+                            {offer && <span className="px-3 py-1 ml-1 text-xs text-black bg-white rounded-full ">You</span>}
+                          </a>
+                        </div>
+                        <div>
+                          <span className='sol-amount'>{toSOL(offer.price)}</span>
+                        </div>
+                        <div>{format(offer.createdAt, 'en_US')}</div>
+                        <CancelOfferForm nft={data?.nft} marketplace={marketplace} offer={offer} />
+                      </article>
+                    ))
+                  )}
                 </section>
               )
             )(offers)}
           </div>
         </div>
-      </div>
+      </div >
     </>
   )
 }


### PR DESCRIPTION
### Goal
Update the UI after an action by refetching the nft information including listings and offerts.

### Changes
- Move nft query of serverSideProps and into client so it can be refetched.
- Add loading state to the NFT detail page while its requesting the NFT.
- All actions call refetch after the transaction was submitted to update the UI based on the new results available in the indexer.

![Screen Shot 2022-03-08 at 1 25 38 PM](https://user-images.githubusercontent.com/2388118/157333449-143d30ea-1e16-4c3c-95f5-fd9435afbbef.png)
