### PR TITLE
Page Meta, Connecting, 404s, and more

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,9 @@ const client = new ApolloClient({
                   }
                 }
             },
+            StoreCreator: {
+                keyFields: ['creatorAddress', 'storeConfigAddress']
+            },
             Marketplace: {
                 keyFields: ['ownerAddress'],
             },

--- a/src/components/NftCard/NftCard.tsx
+++ b/src/components/NftCard/NftCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { find, pipe, prop, equals } from 'ramda';
+import { find, pipe, prop, equals, not } from 'ramda';
 import { Nft, Marketplace, Listing } from './../../types';
 import { Link } from 'react-router-dom';
 import { toSOL } from './../../modules/lamports';
+import { useWallet } from '@solana/wallet-adapter-react';
 
 interface NftCardProps {
   nft: Nft;
@@ -10,12 +11,15 @@ interface NftCardProps {
 }
 
 export const NftCard = ({ nft, marketplace }: NftCardProps) => {
+  const { publicKey } = useWallet();
   const listing = find<Listing>(
     pipe(
       prop('auctionHouse'),
       equals(marketplace.auctionHouse.address)
     )
   )(nft.listings);
+
+  const isOwner = equals(nft.owner.address, publicKey?.toBase58());
 
   return (
     <article className='overflow-hidden rounded-lg transition duration-100 transform cursor-pointer bg-gray-900 shadow-card	hover:scale-[1.02]'>
@@ -31,23 +35,28 @@ export const NftCard = ({ nft, marketplace }: NftCardProps) => {
         <div className='flex items-center'>
         </div>
       </header>
-      <footer className='flex justify-end items-center h-20 gap-2 px-4 border-t-gray-800 border-t-2'>
+      <footer className='flex justify-end items-center gap-2 px-4 h-20 border-t-gray-800 border-t-2'>
         {listing ? (
           <>
             <div className='flex-1 mr-auto'>
               <p className='label'>Price</p>
               <p className='font-semibold icon-sol'>{toSOL(listing.price)}</p>
             </div>
-            <Link to={`/nfts/${nft.address}`}>
-              <button className='button small grow-0'>Buy Now</button>
-            </Link>
+            {not(isOwner) && (
+              <Link to={`/nfts/${nft.address}`}>
+                <button className='button small grow-0'>Buy Now</button>
+              </Link>
+            )}
           </>
         ) : (
-          <Link to={`/nfts/${nft.address}/offers/new`}>
-            <button className='button tertiary small grow-0'>Make Offer</button>
-          </Link>
+          not(isOwner) && (
+            <Link to={`/nfts/${nft.address}/offers/new`}>
+              <button className='button tertiary small grow-0'>Make Offer</button>
+            </Link>
+          )
         )}
       </footer>
+
     </article>
   )
 }

--- a/src/components/Offer/index.tsx
+++ b/src/components/Offer/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { useForm } from 'react-hook-form'
-import { Link } from 'react-router-dom'
-import { useRouter } from 'next/router'
+import { Link, useNavigate } from 'react-router-dom'
 import { AuctionHouseProgram } from '@metaplex-foundation/mpl-auction-house'
 import { OperationVariables, ApolloQueryResult } from '@apollo/client'
 import { MetadataProgram } from '@metaplex-foundation/mpl-token-metadata'
@@ -34,7 +33,7 @@ const Offer = ({ nft, marketplace, refetch }: OfferProps) => {
   const { handleSubmit, register, formState: { isSubmitting } } = useForm<OfferForm>({})
   const { publicKey, signTransaction } = useWallet()
   const { connection } = useConnection()
-  const router = useRouter()
+  const navigate = useNavigate();
 
   const placeOfferTransaction = async ({ amount }: OfferForm) => {
     if (!publicKey || !signTransaction || !nft) {
@@ -151,13 +150,13 @@ const Offer = ({ nft, marketplace, refetch }: OfferProps) => {
         <>The transaction failed. <a target="_blank" rel="noreferrer" href={`https://explorer.solana.com/tx/${signature}`}>View on explore</a>.</>
       )
     } finally {
-      return router.push(`/nfts/${nft.address}`);
+      navigate(`/nfts/${nft.address}`)
     }
   }
 
   return (
     <form
-      className='text-left grow'
+      className='text-left grow mt-6'
       onSubmit={handleSubmit(placeOfferTransaction)}
     >
       <h3 className='mb-6 text-xl font-bold md:text-2xl'>Make an offer</h3>

--- a/src/components/SellNft/index.tsx
+++ b/src/components/SellNft/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { AuctionHouseProgram } from '@metaplex-foundation/mpl-auction-house'
 import { OperationVariables, ApolloQueryResult } from '@apollo/client'
@@ -14,7 +14,6 @@ import {
 } from '@solana/web3.js'
 import { Nft, Marketplace } from '../../types'
 import { toast } from 'react-toastify'
-import { useRouter } from 'next/router';
 
 const {
   createSellInstruction,
@@ -35,7 +34,7 @@ const SellNft = ({ nft, marketplace, refetch }: SellNftProps) => {
   const { control, handleSubmit, formState: { isSubmitting } } = useForm<SellNftForm>({})
   const { publicKey, signTransaction } = useWallet()
   const { connection } = useConnection()
-  const router = useRouter()
+  const navigate = useNavigate()
 
   const sellNftTransaction = async ({ amount }: SellNftForm) => {
     if (!publicKey || !signTransaction || !nft) {
@@ -166,13 +165,13 @@ const SellNft = ({ nft, marketplace, refetch }: SellNftProps) => {
         <>The transaction failed. <a target="_blank" rel="noreferrer" href={`https://explorer.solana.com/tx/${signature}`}>View on explore</a>.</>
       )
     } finally {
-      return router.push(`/nfts/${nft.address}`);
+      return navigate(`/nfts/${nft.address}`);
     }
   }
 
   return (
     <form
-      className='text-left grow'
+      className='text-left grow mt-6'
       onSubmit={handleSubmit(sellNftTransaction)}
     >
       <h3 className='mb-6 text-xl font-bold md:text-2xl'>Sell this Nft</h3>

--- a/src/components/WalletPortal/WalletPortal.tsx
+++ b/src/components/WalletPortal/WalletPortal.tsx
@@ -1,12 +1,12 @@
-import { always, isNil, ifElse, not, or } from 'ramda';
+import { isNil, not, or } from 'ramda';
 import { useQuery, gql } from '@apollo/client';
 import { useWallet } from "@solana/wallet-adapter-react";
 import * as Popover from '@radix-ui/react-popover';
-import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import Button, { ButtonSize, ButtonType } from "../Button";
 import { toSOL } from '../../modules/lamports';
 import { Viewer } from './../../types.d';
 import { truncateAddress } from '../../modules/address';
+import { useLogin } from './../../hooks/login';
 
 const GET_VIEWER = gql`
   query GetViewer {
@@ -21,22 +21,9 @@ interface GetViewerData {
 }
 
 const WalletPortal = () => {
-  const { wallet, connect, connected, publicKey, disconnect, connecting } = useWallet();
+  const login = useLogin();
+  const { connected, publicKey, disconnect, connecting } = useWallet();
   const { loading, data } = useQuery<GetViewerData>(GET_VIEWER);
-
-  const { setVisible } = useWalletModal();
-
-  const openModal = async () => {
-    setVisible(true);
-
-    return Promise.resolve();
-  };
-
-  const onConnect = ifElse(
-    isNil,
-    always(openModal),
-    always(connect),
-  )(wallet);
 
   const isLoading = loading || connecting;
 
@@ -95,7 +82,7 @@ const WalletPortal = () => {
       </Popover.Root>
     ) : (
       <Button
-        onClick={onConnect}
+        onClick={login}
         size={ButtonSize.Small}
       >
         Connect

--- a/src/hooks/login/index.ts
+++ b/src/hooks/login/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/src/hooks/login/login.ts
+++ b/src/hooks/login/login.ts
@@ -1,0 +1,23 @@
+import { useWallet } from "@solana/wallet-adapter-react";
+import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import { ifElse, always, isNil } from "ramda";
+
+export const useLogin = () => {
+  const { wallet, connect } = useWallet();
+
+  const { setVisible } = useWalletModal();
+
+  const openModal = async () => {
+    setVisible(true);
+
+    return Promise.resolve();
+  };
+
+  const onConnect = ifElse(
+    isNil,
+    always(openModal),
+    always(connect),
+  )(wallet);
+
+  return onConnect;
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,6 +1,10 @@
 
 const NotFound = () => {
-  return (<h1>Page not found</h1>)
+  return (
+    <section className="flex w-full justify-center pt-12">
+      <h1 className="text-2xl text-white">Page not found</h1>
+    </section>
+  )
 }
 
 export default NotFound;

--- a/src/pages/creators/[creator].tsx
+++ b/src/pages/creators/[creator].tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react'
 import { NextPage, NextPageContext } from 'next'
 import { gql, useQuery } from '@apollo/client'
 import { Link } from 'react-router-dom'
+import Head from 'next/head';
 import { useWallet } from '@solana/wallet-adapter-react'
 import WalletPortal from '../../components/WalletPortal';
-import { isNil, map, modify, filter, partial, pipe, prop, isEmpty, not, any, equals, ifElse, always, when, length } from 'ramda'
+import { isNil, map, modify, filter, gt, partial, pipe, prop, isEmpty, not, any, equals, ifElse, always, when, length } from 'ramda'
 import { useRouter } from "next/router";
 import { AppProps } from 'next/app'
 import Select from 'react-select'
@@ -54,6 +55,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
   const {
     data: { marketplace, creator },
   } = await client.query<GetCreatorPage>({
+    fetchPolicy: 'no-cache',
     query: gql`
       query GetCreatorPage($subdomain: String!, $creator: String!) {
         marketplace(subdomain: $subdomain) {
@@ -134,7 +136,7 @@ const CreatorShow: NextPage<CreatorPageProps> = ({ marketplace, creator }) => {
   const { publicKey, connected } = useWallet();
   const [hasMore, setHasMore] = useState(true);
   const router = useRouter();
-  const  { data, loading, refetch, fetchMore, variables } = useQuery<GetNftsData>(GET_NFTS, {
+  const { data, loading, refetch, fetchMore, variables } = useQuery<GetNftsData>(GET_NFTS, {
     variables: {
       creators: [router.query.creator],
       offset: 0,
@@ -181,6 +183,12 @@ const CreatorShow: NextPage<CreatorPageProps> = ({ marketplace, creator }) => {
 
   return (
     <div className='flex flex-col items-center text-white bg-gray-900'>
+      <Head>
+        <title>
+          {truncateAddress(router.query?.creator as string)} NFT Collection | {marketplace.name}
+        </title>
+        <link rel="icon" href={marketplace.logoUrl} />
+      </Head>
       <div className='relative w-full'>
         <div className="absolute right-6 top-[25px]">
           <WalletPortal />
@@ -292,9 +300,11 @@ const CreatorShow: NextPage<CreatorPageProps> = ({ marketplace, creator }) => {
               </ul>
               <div className="flex flex-row justify-between align-top w-full mb-2">
                 <label className="label">Creators</label>
-                <Link to="/">
+                {pipe(length, gt(1))(marketplace.creators) && (
+                  <Link to="/">
                     Show All
-                </Link>
+                  </Link>
+                )}
               </div>
               <ul className="flex flex-col flex-grow mb-6">
                 <li className='flex justify-between w-full px-4 py-2 mb-1 rounded-md bg-gray-800 hover:bg-gray-800'>
@@ -348,7 +358,7 @@ const CreatorShow: NextPage<CreatorPageProps> = ({ marketplace, creator }) => {
                 if (not(inView)) {
                   return;
                 }
-                
+
                 const { data: { nfts } } = await fetchMore({
                   variables: {
                     ...variables,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { NextPage, NextPageContext } from 'next'
 import { gql, useQuery } from '@apollo/client'
+import Head from 'next/head';
 import { Link } from 'react-router-dom'
 import WalletPortal from '../components/WalletPortal';
 import cx from 'classnames';
@@ -118,7 +119,7 @@ interface NftFilterForm {
 const Home: NextPage<HomePageProps> = ({ marketplace }) => {
   const { publicKey, connected } = useWallet();
   const creators = map(prop('creatorAddress'))(marketplace.creators);
-  
+
   const { data, loading, refetch, fetchMore, variables } = useQuery<GetNftsData>(GET_NFTS, {
     variables: {
       creators,
@@ -163,6 +164,12 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
 
   return (
     <div className='flex flex-col items-center text-white bg-gray-900'>
+      <Head>
+        <title>
+          {marketplace.name}
+        </title>
+        <link rel="icon" href={marketplace.logoUrl} />
+      </Head>
       <div className='relative w-full'>
         <div className="absolute right-6 top-[25px]">
           <WalletPortal />
@@ -216,7 +223,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                   />
                 </li>
                 <li>
-                <Controller
+                  <Controller
                     control={control}
                     name="preset"
                     render={({ field: { value, onChange } }) => (
@@ -244,32 +251,32 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                 </li>
                 {connected && (
                   <li>
-                <Controller
-                    control={control}
-                    name="preset"
-                    render={({ field: { value, onChange } }) => (
-                      <label
-                        htmlFor="preset-owned"
-                        className={
-                          cx(
-                            "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
-                            { "bg-gray-800": equals(PresetNftFilter.Owned, value) }
-                          )
-                        }
-                      >
-                        <input
-                          onChange={onChange}
-                          className="hidden"
-                          type="radio"
-                          name="preset"
-                          value={PresetNftFilter.Owned}
-                          id="preset-owned"
-                        />
-                        Owned by me
-                      </label>
+                    <Controller
+                      control={control}
+                      name="preset"
+                      render={({ field: { value, onChange } }) => (
+                        <label
+                          htmlFor="preset-owned"
+                          className={
+                            cx(
+                              "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
+                              { "bg-gray-800": equals(PresetNftFilter.Owned, value) }
+                            )
+                          }
+                        >
+                          <input
+                            onChange={onChange}
+                            className="hidden"
+                            type="radio"
+                            name="preset"
+                            value={PresetNftFilter.Owned}
+                            id="preset-owned"
+                          />
+                          Owned by me
+                        </label>
 
-                    )}
-                  />
+                      )}
+                    />
                   </li>
                 )}
               </ul>
@@ -278,7 +285,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                 {creators.map((creator) => (
                   <li key={creator}>
                     <Link to={`/creators/${creator}`} className='flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800'>
-                        <h4>{truncateAddress(creator)}</h4>
+                      <h4>{truncateAddress(creator)}</h4>
                     </Link>
                   </li>
                 ))}
@@ -295,7 +302,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                 if (not(inView)) {
                   return;
                 }
-                
+
                 const { data: { nfts } } = await fetchMore({
                   variables: {
                     ...variables,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,6 +29,9 @@ const GET_NFTS = gql`
       name
       description
       image
+      owner {
+        address
+      }
       listings {
         address
         auctionHouse
@@ -54,6 +57,7 @@ export async function getServerSideProps({ req }: NextPageContext) {
           ownerAddress
           creators {
             creatorAddress
+            storeConfigAddress
           }
           auctionHouse {
             address

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -15,7 +15,8 @@ import {
   and,
   not,
   concat
-} from 'ramda'
+} from 'ramda';
+import Head from 'next/head';
 import cx from 'classnames';
 import client from '../../client';
 import { useRouter } from 'next/router';
@@ -269,7 +270,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
     ] = await AuctionHouseProgram.findAssociatedTokenAccountAddress(
       tokenMint,
       publicKey
-      
+
     )
 
     const [
@@ -509,6 +510,12 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
 
   return (
     <>
+      <Head>
+        <title>
+          {truncateAddress(router.query?.address as string)} NFT | {marketplace.name}
+        </title>
+        <link rel="icon" href={marketplace.logoUrl} />
+      </Head>
       <div className='sticky top-0 z-10 flex items-center justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow'>
         <Link to='/'>
           <a>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -14,7 +14,7 @@ interface GraphQLObject {
 }
 
 export interface MarketplaceCreator {
-  creatorAddress: string;
+  creatorAddress: string,
   storeConfigAddress: string;
 }
 


### PR DESCRIPTION
### Changes
- Add page meta to each page using `next/head`
- 404 pages when the account isn't associated to the marketplace.
- Hide offer and buy button on collection view for NFTs owned by the current user.
- Prompt user to connect on nft detail page
- Fix navigating after action. Switch to react-router navigate. Again next router is linked up with react-router.
- Adjust offers table between 3/4 grid if the user can cancel or accept offers.


![Screen Shot 2022-03-10 at 11 32 51 AM](https://user-images.githubusercontent.com/2388118/157773288-d445e921-8b30-451f-a610-b4bb11f2fb29.png)
![Screen Shot 2022-03-10 at 3 19 05 PM](https://user-images.githubusercontent.com/2388118/157773297-d7d52a1e-9043-4b80-8f8e-eeb013aa9197.png)
![Screen Shot 2022-03-10 at 1 04 07 PM](https://user-images.githubusercontent.com/2388118/157773320-867eeb3f-c086-4df8-b6f6-4711e2e1426f.png)
