### PR TITLE
Mobile Friendly Attribute Filters

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   async rewrites() {
-    console.log('register rewrites')
     return [
       {
         source: '/nfts/:address/listings/new',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ramda": "^0.28.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-feather": "^2.0.9",
     "react-hook-form": "^7.25.1",
     "react-intersection-observer": "^8.33.1",
     "react-loader-spinner": "^6.0.0-0",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,3 +2,5 @@ import { makeVar } from '@apollo/client';
 import { Viewer } from './types.d';
 
 export const viewerVar = makeVar<Viewer | null>(null);
+
+export const sidebarOpenVar = makeVar<boolean>(false);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,6 @@
 import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
 import { offsetLimitPagination } from "@apollo/client/utilities";
-import { construct } from 'ramda';
 import BN from 'bn.js';
-
 import { viewerVar } from './cache';
 
 const asBN = (value: string) => new BN(value);
@@ -10,6 +8,7 @@ const asBN = (value: string) => new BN(value);
 const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT;
 
 const typeDefs = gql`
+
   type Viewer {
     id: ID
     balance: Number

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -21,6 +21,7 @@ interface ButtonProps {
   type?: ButtonType;
   disabled?: boolean;
   loading?: boolean;
+  icon?: React.ReactElement;
   className?: string;
   onClick?: () => any;
 }
@@ -33,6 +34,7 @@ const isSmall = equals(ButtonSize.Small);
 
 const Button = ({
   children,
+  icon,
   size = ButtonSize.Large,
   htmlType = 'button',
   disabled = false,
@@ -46,13 +48,13 @@ const Button = ({
     <button
       className={cx(
         className,
-        'flex items-center text-center justify-center relative duration-150 rounded-full focus:shadow-outline hover:scale-[1.02] transition-transform grow',
+        'flex items-center text-center justify-center duration-150 rounded-full focus:shadow-outline hover:scale-[1.02] transition-transform grow',
         {
           'w-full': block,
           'text-black bg-white': isPrimary(type),
           'text-white bg-gray-900': isSecondary(type),
           'text-gray-300 bg-gray-700': isTertiary(type),
-          'text-sm p-2': isSmall(size),
+          'text-sm py-2 px-4': isSmall(size),
           'p-4': isLarge(size),
         }
       )}
@@ -74,6 +76,7 @@ const Button = ({
             wrapperClass="inline aspect-square mr-1"
           />
         )}
+        {icon && icon}
         {children}
     </button>
   );

--- a/src/hooks/sidebar/index.ts
+++ b/src/hooks/sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar';

--- a/src/hooks/sidebar/sidebar.ts
+++ b/src/hooks/sidebar/sidebar.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect } from "react";
+import { useReactiveVar } from '@apollo/client';
+import { sidebarOpenVar } from "../../cache";
+
+interface SidebarContext {
+  sidebarOpen: boolean;
+  toggleSidebar: () => void,
+}
+
+export const useSidebar = (): SidebarContext => {
+  const sidebarOpen = useReactiveVar(sidebarOpenVar);
+
+  const toggleSidebar = useCallback(() => {
+    const next = !!!sidebarOpen;
+
+    if (next) {
+      document?.querySelector("body")?.classList.add('overflow-hidden');
+    } else {
+      document?.querySelector("body")?.classList.remove('overflow-hidden');
+    }
+
+    sidebarOpenVar(next);
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const resize = () => {
+      if (window.innerHeight > 640) {
+        document?.querySelector("body")?.classList.remove('overflow-hidden');
+        sidebarOpenVar(false);
+      }
+    }
+
+    window.addEventListener('resize', resize);
+
+    () => window.removeEventListener('resize', resize);
+  }, []);
+
+  return { sidebarOpen, toggleSidebar };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -72,7 +72,7 @@ function App({ Component, pageProps }: AppProps) {
                 theme="dark"
                 hideProgressBar={true}
                 position='bottom-center'
-                className="w-full max-w-full font-sans text-sm text-white bottom-4 sm:right-4 sm:left-auto sm:w-96 sm:translate-x-0 "
+                className="w-full max-w-full font-sans text-sm text-white bottom-4 sm:right-4 sm:left-auto sm:w-96 sm:translate-x-0"
                 toastClassName="bg-gray-900 bg-opacity-80 rounded-lg items-center"
               />
               <Component {...pageProps} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,10 +10,13 @@ import { truncateAddress } from '../modules/address';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { AppProps } from 'next/app'
 import { useForm, Controller } from 'react-hook-form'
-import client from '../client'
+import client from '../client';
 import { Marketplace, Creator, Nft, PresetNftFilter, AttributeFilter } from '../types.d';
 import { List } from './../components/List';
 import { NftCard } from './../components/NftCard';
+import Button, { ButtonSize } from '../components/Button';
+import { Filter } from 'react-feather';
+import { useSidebar } from '../hooks/sidebar';
 
 const SUBDOMAIN = process.env.MARKETPLACE_SUBDOMAIN;
 
@@ -132,6 +135,8 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
     },
   });
 
+  const { sidebarOpen, toggleSidebar } = useSidebar();
+
   const [hasMore, setHasMore] = useState(true);
 
   const { watch, control } = useForm<NftFilterForm>({
@@ -191,80 +196,31 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
           <p className='mt-4 max-w-prose'>{marketplace.description}</p>
         </div>
         <div className='flex'>
-          <div className='flex-row flex-none hidden mr-10 space-y-2 w-80 sm:block'>
-            <form
-              onSubmit={e => {
-                e.preventDefault()
-              }}
-              className='sticky top-0 max-h-screen py-4 overflow-auto'
-            >
-              <ul className='flex flex-col flex-grow mb-6'>
-                <li>
-                  <Controller
-                    control={control}
-                    name="preset"
-                    render={({ field: { value, onChange } }) => (
-                      <label
-                        htmlFor="preset-all"
-                        className={
-                          cx(
-                            "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
-                            { "bg-gray-800": equals(PresetNftFilter.All, value) }
-                          )
-                        }
-                      >
-                        <input
-                          onChange={onChange}
-                          className="hidden"
-                          type="radio"
-                          name="preset"
-                          value={PresetNftFilter.All}
-                          id="preset-all"
-                        />
-                        All
-                      </label>
-                    )}
-                  />
-                </li>
-                <li>
-                  <Controller
-                    control={control}
-                    name="preset"
-                    render={({ field: { value, onChange } }) => (
-                      <label
-                        htmlFor="preset-listed"
-                        className={
-                          cx(
-                            "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
-                            { "bg-gray-800": equals(PresetNftFilter.Listed, value) }
-                          )
-                        }
-                      >
-                        <input
-                          onChange={onChange}
-                          className="hidden"
-                          type="radio"
-                          name="preset"
-                          value={PresetNftFilter.Listed}
-                          id="preset-listed"
-                        />
-                        Listed for sale
-                      </label>
-                    )}
-                  />
-                </li>
-                {connected && (
+          <div className="relative">
+            <div className={cx(
+              'fixed top-0 right-0 bottom-0 left-0 z-10 bg-gray-900 flex-row flex-none space-y-2 sm:sticky sm:block sm:w-80 sm:mr-10  overflow-auto h-screen',
+              {
+                'hidden': not(sidebarOpen),
+              }
+            )}>
+              <form
+                onSubmit={e => {
+                  e.preventDefault()
+                }}
+                className='py-4 px-4 sm:px-0'
+              >
+                <ul className='flex flex-col flex-grow mb-6'>
                   <li>
                     <Controller
                       control={control}
                       name="preset"
                       render={({ field: { value, onChange } }) => (
                         <label
-                          htmlFor="preset-owned"
+                          htmlFor="preset-all"
                           className={
                             cx(
                               "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
-                              { "bg-gray-800": equals(PresetNftFilter.Owned, value) }
+                              { "bg-gray-800": equals(PresetNftFilter.All, value) }
                             )
                           }
                         >
@@ -273,28 +229,84 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                             className="hidden"
                             type="radio"
                             name="preset"
-                            value={PresetNftFilter.Owned}
-                            id="preset-owned"
+                            value={PresetNftFilter.All}
+                            id="preset-all"
                           />
-                          Owned by me
+                          All
                         </label>
-
                       )}
                     />
                   </li>
-                )}
-              </ul>
-              <label className="mb-2 label">Creators</label>
-              <ul className="flex flex-col flex-grow mb-6">
-                {creators.map((creator) => (
-                  <li key={creator}>
-                    <Link to={`/creators/${creator}`} className='flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800'>
-                      <h4>{truncateAddress(creator)}</h4>
-                    </Link>
+                  <li>
+                    <Controller
+                      control={control}
+                      name="preset"
+                      render={({ field: { value, onChange } }) => (
+                        <label
+                          htmlFor="preset-listed"
+                          className={
+                            cx(
+                              "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
+                              { "bg-gray-800": equals(PresetNftFilter.Listed, value) }
+                            )
+                          }
+                        >
+                          <input
+                            onChange={onChange}
+                            className="hidden"
+                            type="radio"
+                            name="preset"
+                            value={PresetNftFilter.Listed}
+                            id="preset-listed"
+                          />
+                          Listed for sale
+                        </label>
+                      )}
+                    />
                   </li>
-                ))}
-              </ul>
-            </form>
+                  {connected && (
+                    <li>
+                      <Controller
+                        control={control}
+                        name="preset"
+                        render={({ field: { value, onChange } }) => (
+                          <label
+                            htmlFor="preset-owned"
+                            className={
+                              cx(
+                                "flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800",
+                                { "bg-gray-800": equals(PresetNftFilter.Owned, value) }
+                              )
+                            }
+                          >
+                            <input
+                              onChange={onChange}
+                              className="hidden"
+                              type="radio"
+                              name="preset"
+                              value={PresetNftFilter.Owned}
+                              id="preset-owned"
+                            />
+                            Owned by me
+                          </label>
+
+                        )}
+                      />
+                    </li>
+                  )}
+                </ul>
+                <label className="mb-2 label">Creators</label>
+                <ul className="flex flex-col flex-grow mb-6">
+                  {creators.map((creator) => (
+                    <li key={creator}>
+                      <Link to={`/creators/${creator}`} className='flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800'>
+                        <h4>{truncateAddress(creator)}</h4>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </form>
+            </div>
           </div>
           <div className='grow'>
             <List
@@ -338,6 +350,14 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
           </div>
         </div>
       </div>
+      <Button
+        size={ButtonSize.Small}
+        icon={<Filter size={16} className="mr-2" />}
+        className="fixed bottom-4 z-10 sm:hidden"
+        onClick={toggleSidebar}
+      >
+        Filter
+      </Button>
     </div>
   )
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -48,7 +48,7 @@ export interface AttributeGroup {
 }
 
 export interface Creator {
-  addresss: string
+  address: string
   attributeGroups: AttributeGroup[]
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,6 +4288,13 @@ react-dom@17.0.2, react-dom@^17.0.0:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-feather@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.9.tgz#6e42072130d2fa9a09d4476b0e61b0ed17814480"
+  integrity sha512-yMfCGRkZdXwIs23Zw/zIWCJO3m3tlaUvtHiXlW+3FH7cIT6fiK1iJ7RJWugXq7Fso8ZaQyUm92/GOOHXvkiVUw==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-hook-form@^7.25.1:
   version "7.25.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.25.1.tgz#7ec58505078760134b1c6efdfe07b4b5c4bdb8e3"


### PR DESCRIPTION
### Changes
- Mobile friendly attribute sidebar
- Fetch attribute filter on the client in parallel with the initial batch of nfts
- Loading state while querying attribute filters
- Hide the sidebar when reaches small breakpoint

<img width="1025" alt="Screen Shot 2022-03-15 at 3 31 48 PM" src="https://user-images.githubusercontent.com/2388118/158467832-0ecdb206-ea10-4987-b9c8-8323782de043.png">
<img width="484" alt="Screen Shot 2022-03-15 at 3 30 21 PM" src="https://user-images.githubusercontent.com/2388118/158467896-04ca279e-b4e9-4e1c-bf1b-f867acd21580.png">
<img width="492" alt="Screen Shot 2022-03-15 at 3 30 05 PM" src="https://user-images.githubusercontent.com/2388118/158467929-0ec3a393-c25f-42c1-93a5-73e7af9c23fe.png">
