### PR TITLE
Marketplace and Collection Stats

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,10 @@
 import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
 import { offsetLimitPagination } from '@apollo/client/utilities'
+import { ifElse, constructN, isNil } from 'ramda'
 import BN from 'bn.js'
 import { viewerVar } from './cache'
 
-const asBN = (value: string) => new BN(value)
+const asBN = ifElse(isNil, () => new BN(0), constructN(1, BN))
 
 const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
 
@@ -30,6 +31,19 @@ const client = new ApolloClient({
             read() {
               return viewerVar()
             },
+          },
+        },
+      },
+      MintStats: {
+        fields: {
+          volume24hr: {
+            read: asBN,
+          },
+          average: {
+            read: asBN,
+          },
+          floor: {
+            read: asBN,
           },
         },
       },

--- a/src/pages/admin/creators/edit.tsx
+++ b/src/pages/admin/creators/edit.tsx
@@ -194,7 +194,7 @@ const AdminEditCreators = ({ marketplace }: AdminEditCreatorsProps) => {
     <div className="flex flex-col items-center text-white bg-gray-900">
       <div className="fixed top-0 z-10 flex items-center w-full justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
         <Link to="/">
-          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
+          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600 transition-transform hover:scale-[1.02]">
             <img
               className="w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
               src={marketplace.logoUrl}
@@ -220,7 +220,7 @@ const AdminEditCreators = ({ marketplace }: AdminEditCreatorsProps) => {
         <div className="relative w-full mt-20 mb-1">
           <img
             src={marketplace.logoUrl}
-            className="absolute border-4 border-gray-900 object-cover rounded-full w-28 h-28 -top-32"
+            className="object-cover w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
           />
         </div>
         <div className="flex flex-col md:flex-row">

--- a/src/pages/admin/marketplace/edit.tsx
+++ b/src/pages/admin/marketplace/edit.tsx
@@ -183,9 +183,9 @@ const AdminEditMarketplace = ({ marketplace }: AdminEditMarketplaceProps) => {
       <div className="flex flex-col items-center text-white bg-gray-900">
         <div className="fixed top-0 z-10 flex items-center w-full justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
           <Link to="/">
-            <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
+            <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600 transition-transform hover:scale-[1.02]">
               <img
-                className="w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
+                className="object-cover w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
                 src={marketplace.logoUrl}
               />
               <div className="hidden sm:block">{marketplace.name}</div>

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -36,7 +36,6 @@ import {
   Nft,
   PresetNftFilter,
   AttributeFilter,
-  MarketplaceCreator,
 } from '../../types.d'
 import { List } from '../../components/List'
 import { NftCard } from '../../components/NftCard'
@@ -44,6 +43,7 @@ import Button, { ButtonSize } from '../../components/Button'
 import cx from 'classnames'
 import { useSidebar } from '../../hooks/sidebar'
 import { Filter } from 'react-feather'
+import { toSOL } from '../../modules/lamports'
 
 const SUBDOMAIN = process.env.MARKETPLACE_SUBDOMAIN
 
@@ -59,6 +59,7 @@ const GET_NFTS = gql`
     $creators: [PublicKey!]!
     $owners: [PublicKey!]
     $listed: [PublicKey!]
+    $offerers: [PublicKey!]
     $limit: Int!
     $offset: Int!
     $attributes: [AttributeFilter!]
@@ -67,6 +68,7 @@ const GET_NFTS = gql`
       creators: $creators
       owners: $owners
       listed: $listed
+      offerers: $offerers
       limit: $limit
       offset: $offset
       attributes: $attributes
@@ -90,10 +92,20 @@ const GET_NFTS = gql`
   }
 `
 
-const GET_SIDEBAR = gql`
-  query GetCollectionSidebar($creator: String!) {
+const GET_COLLECTION_INFO = gql`
+  query GetCollectionInfo($creator: String!, $auctionHouses: [PublicKey!]!) {
     creator(address: $creator) {
       address
+      stats(auctionHouses: $auctionHouses) {
+        mint
+        auctionHouse
+        volume24hr
+        average
+        floor
+      }
+      counts {
+        creations
+      }
       attributeGroups {
         name
         variants {
@@ -181,7 +193,7 @@ interface GetCollectionPage {
   creator: Creator | null
 }
 
-interface GetCollectionSidebarData {
+interface GetCollectionInfo {
   creator: Creator
 }
 
@@ -217,12 +229,12 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
     },
   })
 
-  const { data: sidebar, loading: loadingSidebar } =
-    useQuery<GetCollectionSidebarData>(GET_SIDEBAR, {
-      variables: {
-        creator: router.query.collection,
-      },
-    })
+  const collectionQuery = useQuery<GetCollectionInfo>(GET_COLLECTION_INFO, {
+    variables: {
+      creator: router.query.collection,
+      auctionHouses: [marketplace.auctionHouse.address],
+    },
+  })
 
   const { sidebarOpen, toggleSidebar } = useSidebar()
 
@@ -230,7 +242,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
     defaultValues: { preset: PresetNftFilter.All },
   })
 
-  const loading = loadingNfts || loadingSidebar
+  const loading = loadingNfts || collectionQuery.loading
 
   useEffect(() => {
     const subscription = watch(({ attributes, preset }) => {
@@ -295,9 +307,9 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
       </Head>
       <div className="relative w-full">
         <Link to="/" className="absolute top-6 left-6">
-          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
+          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600 transition-transform hover:scale-[1.02]">
             <img
-              className="w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
+              className="object-cover w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
               src={marketplace.logoUrl}
             />
             <div className="hidden sm:block">{marketplace.name}</div>
@@ -311,7 +323,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
             ) && (
               <Link
                 to="/admin/marketplace/edit"
-                className="text-sm cursor-pointer mr-6 hover:underline "
+                className="text-sm cursor-pointer mr-6 hover:underline"
               >
                 Admin Dashboard
               </Link>
@@ -326,16 +338,75 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
         />
       </div>
       <div className="w-full max-w-[1800px] px-8">
-        <div className="relative flex flex-col justify-between w-full mt-20 mb-20">
-          <img
-            src={marketplace.logoUrl}
-            alt={marketplace.name}
-            className="absolute border-4 bg-gray-900 object-cover border-gray-900 rounded-full w-28 h-28 -top-32"
-          />
-          <h2 className="text-sm text-gray-300"
-          >{truncateAddress(router.query?.collection as string)}</h2>
-          <h1 className="mb-4">{marketplace.name}</h1>
-          <p>{marketplace.description}</p>
+        <div className="relative grid grid-cols-12 gap-4 justify-between w-full mt-20 mb-20">
+          <div className="col-span-12 md:col-span-8 mb-6">
+            <img
+              src={marketplace.logoUrl}
+              alt={marketplace.name}
+              className="absolute border-4 bg-gray-900 object-cover border-gray-900 rounded-full w-28 h-28 -top-32"
+            />
+            <h2 className="text-sm text-gray-300">
+              {truncateAddress(router.query?.collection as string)}
+            </h2>
+            <h1 className="mb-4">{marketplace.name}</h1>
+            <p>{marketplace.description}</p>
+          </div>
+          <div className="col-span-12 md:col-span-4 grid grid-cols-2 gap-4">
+            <div>
+              <span className="text-gray-300 uppercase font-semibold text-sm block w-full mb-2">
+                Floor
+              </span>
+              {loading ? (
+                <div className="block bg-gray-800 w-20 h-6 rounded" />
+              ) : (
+                <span className="sol-amount text-xl">
+                  {toSOL(
+                    collectionQuery.data?.creator.stats[0].floor.toNumber() as number
+                  )}
+                </span>
+              )}
+            </div>
+            <div>
+              <span className="text-gray-300 uppercase font-semibold text-sm block w-full mb-2">
+                Vol Last 24 hrs
+              </span>
+              {loading ? (
+                <div className="block bg-gray-800 w-20 h-6 rounded" />
+              ) : (
+                <span className="sol-amount text-xl">
+                  {toSOL(
+                    collectionQuery.data?.creator.stats[0].volume24hr.toNumber() as number
+                  )}
+                </span>
+              )}
+            </div>
+            <div>
+              <span className="text-gray-300 uppercase font-semibold text-sm block w-full mb-2">
+                Avg Sale Price
+              </span>
+              {loading ? (
+                <div className="block bg-gray-800 w-16 h-6 rounded" />
+              ) : (
+                <span className="sol-amount text-xl">
+                  {toSOL(
+                    collectionQuery.data?.creator.stats[0].average.toNumber() as number
+                  )}
+                </span>
+              )}
+            </div>
+            <div>
+              <span className="text-gray-300 uppercase font-semibold text-sm block w-full mb-2">
+                NFTs
+              </span>
+              {loading ? (
+                <div className="block bg-gray-800 w-24 h-6 rounded" />
+              ) : (
+                <span className="sol-amount text-xl">
+                  {collectionQuery.data?.creator.counts.creations}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
         <div className="flex">
           <div className="relative">
@@ -497,7 +568,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                       </div>
                     </>
                   ) : (
-                    sidebar?.creator.attributeGroups.map(
+                    collectionQuery.data?.creator.attributeGroups.map(
                       ({ name: group, variants }, index) => (
                         <div
                           className="flex flex-col flex-grow gap-2"

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -424,7 +424,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                 }}
                 className="px-4 sm:px-0 py-4"
               >
-                <ul className="flex flex-col flex-grow mb-6">
+                <ul className="flex flex-col gap-2 flex-grow mb-6">
                   <li>
                     <Controller
                       control={control}
@@ -433,21 +433,25 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                         <label
                           htmlFor="preset-all"
                           className={cx(
-                            'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                            'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                             {
-                              'bg-gray-800': equals(PresetNftFilter.All, value),
+                              'bg-gray-800': or(
+                                equals(PresetNftFilter.All, value),
+                                loading
+                              ),
                             }
                           )}
                         >
                           <input
                             onChange={onChange}
                             className="hidden"
+                            disabled={loading}
                             type="radio"
                             name="preset"
                             value={PresetNftFilter.All}
                             id="preset-all"
                           />
-                          All
+                          {loading ? <div className="h-6 w-full" /> : 'All'}
                         </label>
                       )}
                     />
@@ -460,11 +464,11 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                         <label
                           htmlFor="preset-listed"
                           className={cx(
-                            'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                            'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                             {
-                              'bg-gray-800': equals(
-                                PresetNftFilter.Listed,
-                                value
+                              'bg-gray-800': or(
+                                equals(PresetNftFilter.Listed, value),
+                                loading
                               ),
                             }
                           )}
@@ -472,61 +476,36 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                           <input
                             onChange={onChange}
                             className="hidden"
+                            disabled={loading}
                             type="radio"
                             name="preset"
                             value={PresetNftFilter.Listed}
                             id="preset-listed"
                           />
-                          Listed for sale
+                          {loading ? (
+                            <div className="h-6 w-full" />
+                          ) : (
+                            'Listed for sale'
+                          )}
                         </label>
                       )}
                     />
                   </li>
                   {connected && (
                     <>
-                    <li>
-                      <Controller
-                        control={control}
-                        name="preset"
-                        render={({ field: { value, onChange } }) => (
-                          <label
-                            htmlFor="preset-owned"
-                            className={cx(
-                              'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
-                              {
-                                'bg-gray-800': equals(
-                                  PresetNftFilter.Owned,
-                                  value
-                                ),
-                              }
-                            )}
-                          >
-                            <input
-                              onChange={onChange}
-                              className="hidden"
-                              type="radio"
-                              name="preset"
-                              value={PresetNftFilter.Owned}
-                              id="preset-owned"
-                            />
-                            Owned by me
-                          </label>
-                        )}
-                      />
-                    </li>
-                    <li>
+                      <li>
                         <Controller
                           control={control}
                           name="preset"
                           render={({ field: { value, onChange } }) => (
                             <label
-                              htmlFor="preset-open"
+                              htmlFor="preset-owned"
                               className={cx(
-                                'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                                'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                                 {
-                                  'bg-gray-800': equals(
-                                    PresetNftFilter.OpenOffers,
-                                    value
+                                  'bg-gray-800': or(
+                                    equals(PresetNftFilter.Owned, value),
+                                    loading
                                   ),
                                 }
                               )}
@@ -535,16 +514,56 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
                                 onChange={onChange}
                                 className="hidden"
                                 type="radio"
+                                disabled={loading}
                                 name="preset"
-                                value={PresetNftFilter.OpenOffers}
-                                id="preset-open"
+                                value={PresetNftFilter.Owned}
+                                id="preset-owned"
                               />
-                              My open offers
+                              {loading ? (
+                                <div className="h-6 w-full" />
+                              ) : (
+                                'Owned by me'
+                              )}
                             </label>
                           )}
                         />
                       </li>
-                      </>
+                      <li>
+                        <Controller
+                          control={control}
+                          name="preset"
+                          render={({ field: { value, onChange } }) => (
+                            <label
+                              htmlFor="preset-open"
+                              className={cx(
+                                'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
+                                {
+                                  'bg-gray-800': or(
+                                    equals(PresetNftFilter.OpenOffers, value),
+                                    loading
+                                  ),
+                                }
+                              )}
+                            >
+                              <input
+                                onChange={onChange}
+                                className="hidden"
+                                type="radio"
+                                disabled={loading}
+                                name="preset"
+                                value={PresetNftFilter.OpenOffers}
+                                id="preset-open"
+                              />
+                              {loading ? (
+                                <div className="h-6 w-full" />
+                              ) : (
+                                'My open offers'
+                              )}
+                            </label>
+                          )}
+                        />
+                      </li>
+                    </>
                   )}
                 </ul>
                 <div className="flex flex-col flex-grow gap-4">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import {
   map,
   prop,
   equals,
+  or,
   partial,
   ifElse,
   always,
@@ -262,29 +263,33 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
         always([pubkey]),
         always(null)
       )(preset as PresetNftFilter)
-      
+
       const offerers = ifElse(
         equals(PresetNftFilter.OpenOffers),
         always([pubkey]),
         always(null)
       )(preset as PresetNftFilter)
-      
-      debugger;
+
       const listed = ifElse(
         equals(PresetNftFilter.Listed),
         always([marketplace.auctionHouse.address]),
         always(null)
       )(preset as PresetNftFilter)
 
-      nftsQuery.refetch({
-        creators,
-        owners,
-        offerers,
-        listed,
-        offset: 0,
-      }).then(({ data: { nfts } }) => {
-        pipe(pipe(length, equals(nftsQuery.variables?.limit)), setHasMore)(nfts)
-      })
+      nftsQuery
+        .refetch({
+          creators,
+          owners,
+          offerers,
+          listed,
+          offset: 0,
+        })
+        .then(({ data: { nfts } }) => {
+          pipe(
+            pipe(length, equals(nftsQuery.variables?.limit)),
+            setHasMore
+          )(nfts)
+        })
     })
     return () => subscription.unsubscribe()
   }, [
@@ -460,7 +465,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                 }}
                 className="py-4 px-4 sm:px-0"
               >
-                <ul className="flex flex-col flex-grow mb-6">
+                <ul className="flex flex-col gap-2 flex-grow mb-6">
                   <li>
                     <Controller
                       control={control}
@@ -469,9 +474,12 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                         <label
                           htmlFor="preset-all"
                           className={cx(
-                            'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                            'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                             {
-                              'bg-gray-800': equals(PresetNftFilter.All, value),
+                              'bg-gray-800': or(
+                                equals(PresetNftFilter.All, value),
+                                loading
+                              ),
                             }
                           )}
                         >
@@ -480,10 +488,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                             className="hidden"
                             type="radio"
                             name="preset"
+                            disabled={loading}
                             value={PresetNftFilter.All}
                             id="preset-all"
                           />
-                          All
+                          {loading ? <div className="h-6 w-full" /> : 'All'}
                         </label>
                       )}
                     />
@@ -496,11 +505,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                         <label
                           htmlFor="preset-listed"
                           className={cx(
-                            'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                            'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                             {
-                              'bg-gray-800': equals(
-                                PresetNftFilter.Listed,
-                                value
+                              'bg-gray-800': or(
+                                equals(PresetNftFilter.Listed, value),
+                                loading
                               ),
                             }
                           )}
@@ -508,12 +517,17 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                           <input
                             onChange={onChange}
                             className="hidden"
+                            disabled={loading}
                             type="radio"
                             name="preset"
                             value={PresetNftFilter.Listed}
                             id="preset-listed"
                           />
-                          Listed for sale
+                          {loading ? (
+                            <div className="h-6 w-full" />
+                          ) : (
+                            'Listed for sale'
+                          )}
                         </label>
                       )}
                     />
@@ -528,11 +542,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                             <label
                               htmlFor="preset-owned"
                               className={cx(
-                                'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                                'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                                 {
-                                  'bg-gray-800': equals(
-                                    PresetNftFilter.Owned,
-                                    value
+                                  'bg-gray-800': or(
+                                    equals(PresetNftFilter.Owned, value),
+                                    loading
                                   ),
                                 }
                               )}
@@ -545,7 +559,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                                 value={PresetNftFilter.Owned}
                                 id="preset-owned"
                               />
-                              Owned by me
+                              {loading ? (
+                                <div className="h-6 w-full" />
+                              ) : (
+                                'Owned by me'
+                              )}
                             </label>
                           )}
                         />
@@ -558,11 +576,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                             <label
                               htmlFor="preset-open"
                               className={cx(
-                                'flex justify-between w-full px-4 py-2 mb-1 rounded-md cursor-pointer hover:bg-gray-800',
+                                'flex justify-between w-full px-4 py-2 rounded-md cursor-pointer hover:bg-gray-800',
                                 {
-                                  'bg-gray-800': equals(
-                                    PresetNftFilter.OpenOffers,
-                                    value
+                                  'bg-gray-800': or(
+                                    equals(PresetNftFilter.OpenOffers, value),
+                                    loading
                                   ),
                                 }
                               )}
@@ -570,12 +588,17 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
                               <input
                                 onChange={onChange}
                                 className="hidden"
+                                disabled={loading}
                                 type="radio"
                                 name="preset"
                                 value={PresetNftFilter.OpenOffers}
                                 id="preset-open"
                               />
-                              My open offers
+                              {loading ? (
+                                <div className="h-6 w-full" />
+                              ) : (
+                                'My open offers'
+                              )}
                             </label>
                           )}
                         />

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -558,9 +558,9 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
       </Head>
       <div className="sticky top-0 z-10 flex items-center justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
         <Link to="/">
-          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
+          <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600 transition-transform hover:scale-[1.02]">
             <img
-              className="w-8 h-8 rounded-full aspect-square"
+              className="object-cover w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
               src={marketplace.logoUrl}
             />
             <div className="hidden sm:block">{marketplace.name}</div>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,15 @@
 import BN from 'bn.js'
 
+export type Volume = number
+
+interface MarketplaceStats {
+  nfts: Volume
+}
+
+interface CreatorCounts {
+  creations: number
+}
+
 export interface Marketplace {
   subdomain: string
   name: string
@@ -9,6 +19,7 @@ export interface Marketplace {
   auctionHouse: AuctionHouse
   ownerAddress: string
   creators: MarketplaceCreator[]
+  stats: MarketplaceStats
 }
 
 interface GraphQLObject {
@@ -36,6 +47,7 @@ export interface AuctionHouse {
   sellerFeeBasisPoints: number
   requiresSignOff: boolean
   canChangeSalePrice: boolean
+  stats: MintStats
 }
 
 export interface AttributeVariant {
@@ -48,9 +60,18 @@ export interface AttributeGroup {
   variants: AttributeVariant[]
 }
 
+export interface MintStats {
+  volume24hr: BN
+  average: BN
+  floor: BN
+  mint: string
+  auctionHouse: string
+}
 export interface Creator {
   address: string
   attributeGroups: AttributeGroup[]
+  stats: MintStats[]
+  counts: CreatorCounts
 }
 
 export interface NftAttribute {


### PR DESCRIPTION
### Changes
- Query marketplace and collection stats from the indexer
- Display stats for the marketplace and each collection
- Fix logo for header (use object-cover instead of warping the image)

<img width="757" alt="Screen Shot 2022-03-28 at 8 13 07 AM" src="https://user-images.githubusercontent.com/2388118/160447688-d4d8e220-142e-408c-b031-0424dfbb6819.png">
<img width="521" alt="Screen Shot 2022-03-28 at 9 26 15 AM" src="https://user-images.githubusercontent.com/2388118/160447698-91c83034-e781-4e2f-8dec-341d75c73249.png">
<img width="444" alt="Screen Shot 2022-03-28 at 9 26 20 AM" src="https://user-images.githubusercontent.com/2388118/160447700-bd3f7610-9ab7-4818-b935-bc1b82898e69.png">
<img width="1490" alt="Screen Shot 2022-03-28 at 9 27 22 AM" src="https://user-images.githubusercontent.com/2388118/160447701-bbffdcb5-3cf0-45b2-bd4f-5ebccaa76778.png">
