### PR TITLE
Fixed squished non-square logo

### DIFF
--- a/src/pages/admin/marketplace/edit.tsx
+++ b/src/pages/admin/marketplace/edit.tsx
@@ -185,7 +185,7 @@ const AdminEditMarketplace = ({ marketplace }: AdminEditMarketplaceProps) => {
           <Link to="/">
             <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
               <img
-                className="w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
+                className="w-12 h-12 md:w-8 md:h-8 rounded-full object-cover"
                 src={marketplace.logoUrl}
               />
               <div className="hidden sm:block">{marketplace.name}</div>

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -290,7 +290,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
         <Link to="/" className="absolute top-6 left-6">
           <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
             <img
-              className="w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
+              className="w-12 h-12 md:w-8 md:h-8 rounded-full object-cover"
               src={marketplace.logoUrl}
             />
             <div className="hidden sm:block">{marketplace.name}</div>

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -560,7 +560,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
         <Link to="/">
           <button className="flex items-center justify-between gap-2 bg-gray-800 rounded-full align sm:px-4 sm:py-2 sm:h-14 hover:bg-gray-600">
             <img
-              className="w-8 h-8 rounded-full aspect-square"
+              className="w-8 h-8 rounded-full object-cover"
               src={marketplace.logoUrl}
             />
             <div className="hidden sm:block">{marketplace.name}</div>


### PR DESCRIPTION
Fixes #141 

Non-square logo will not be squished now.

Note: Desktop Browsers does not support non-square favicons, so non-square favicons will remain squished.