### PR TITLE
[Fix] Always Deposit Offer Amount to Escrow

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -71,11 +71,11 @@ const client = new ApolloClient({
       PurchaseReceipt: {
         keyFields: ['address'],
         fields: {
-            price: {
-                read: asBN,
-            },
+          price: {
+            read: asBN,
+          },
         },
-    },
+      },
       ListingReceipt: {
         keyFields: ['address'],
         fields: {

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -60,8 +60,7 @@ import {
   Purchase,
   ActivityType,
 } from '../../types.d'
-import { CornerDownRight, DollarSign, Tag } from 'react-feather'
-import Image from 'next/image'
+import { DollarSign, Tag } from 'react-feather'
 
 const SUBDOMAIN = process.env.MARKETPLACE_SUBDOMAIN
 


### PR DESCRIPTION
### Issue

The public bid instruction only transfers founds out of the user wallet if their isn't enough funds to cover the purchase. When a user makes 2 offers where 1 is larger than the other the second won't trigger a deduction though it will be valid.

### Fix

Always deposit the amount the offer into escrow to not trigger special public bid logic. This allows for clean canceling and organization on monies.

### Example

An example public bid where funds deposited with the offer.

https://solscan.io/tx/5Tovm9FGu4LpQD4YBfymAS6f7x6Xwb1ZjCRCdGk53q9crj2q1gjii3LdEaFWiCKHhgK5S6Nq2KqGMQrYhHw8phJB