### PR TITLE
NFTs - Not a SOL amount

### DIFF
--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -407,7 +407,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
               {loading ? (
                 <div className="block bg-gray-800 w-24 h-6 rounded" />
               ) : (
-                <span className="sol-amount text-xl">
+                <span className="text-xl">
                   {collectionQuery.data?.creator.counts.creations}
                 </span>
               )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -388,7 +388,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
               {loading ? (
                 <div className="block bg-gray-800 w-24 h-6 rounded" />
               ) : (
-                <span className="sol-amount text-xl">
+                <span className="text-xl">
                   {marketplaceQuery.data?.marketplace.stats.nfts}
                 </span>
               )}


### PR DESCRIPTION
Was wondering what this SOL amount represented and then just realized it was a bug. This number corresponds to the total number of NFTs in the marketplace or collection. So, removed the SOL symbol on both pages.