### PR TITLE
Trigger login if user not connected without showing connect button

### DIFF
--- a/src/components/Offer/index.tsx
+++ b/src/components/Offer/index.tsx
@@ -14,6 +14,7 @@ import {
 import { toast } from 'react-toastify'
 import { Nft, Marketplace } from './../../types'
 import Button, { ButtonType } from './../Button'
+import { useLogin } from 'src/hooks/login'
 
 const {
   createPublicBuyInstruction,
@@ -41,9 +42,16 @@ const Offer = ({ nft, marketplace, refetch }: OfferProps) => {
   const { publicKey, signTransaction } = useWallet()
   const { connection } = useConnection()
   const navigate = useNavigate()
+  const login = useLogin()
+
 
   const placeOfferTransaction = async ({ amount }: OfferForm) => {
-    if (!publicKey || !signTransaction || !nft) {
+    if(!publicKey || !signTransaction){
+      login();
+      return
+    }
+    
+    if (!nft) {
       return
     }
 

--- a/src/components/Offer/index.tsx
+++ b/src/components/Offer/index.tsx
@@ -14,7 +14,7 @@ import {
 import { toast } from 'react-toastify'
 import { Nft, Marketplace } from './../../types'
 import Button, { ButtonType } from './../Button'
-import { useLogin } from 'src/hooks/login'
+import { useLogin } from '../../hooks/login'
 
 const {
   createPublicBuyInstruction,

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -253,7 +253,12 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
   activities.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt))
 
   const buyNftTransaction = async () => {
-    if (!publicKey || !signTransaction || !listing || isOwner || !data) {
+    if(!publicKey || !signTransaction){
+      login();
+      return
+    }
+
+    if (!listing || isOwner || !data) {
       return
     }
 
@@ -458,7 +463,12 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
   }
 
   const cancelListingTransaction = async () => {
-    if (!publicKey || !signTransaction || !listing || !isOwner || !data) {
+    if(!publicKey || !signTransaction){
+      login();
+      return
+    }
+
+    if (!listing || !isOwner || !data) {
       return
     }
 
@@ -683,7 +693,6 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
                 </div>
               </div>
               <div className={cx('flex gap-4', { hidden: loading })}>
-                {connected ? (
                   <Routes>
                     <Route
                       path={`/nfts/${data?.nft.address}`}
@@ -766,16 +775,7 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
                       }
                     />
                   </Routes>
-                ) : (
-                  <Button
-                    block
-                    onClick={login}
-                    loading={connecting}
-                    className="mt-6"
-                  >
-                    Connect
-                  </Button>
-                )}
+                
               </div>
             </div>
             <div className="grid grid-cols-2 gap-6 mt-8">


### PR DESCRIPTION
Completes #147

Remove connect button and directly trigger login on click of nft action buttons if the user is not connected.