### PR TITLE
Added og tags to nft, collection and home page

### DIFF
--- a/src/pages/admin/creators/edit.tsx
+++ b/src/pages/admin/creators/edit.tsx
@@ -220,7 +220,7 @@ const AdminEditCreators = ({ marketplace }: AdminEditCreatorsProps) => {
         <div className="relative w-full mt-20 mb-1">
           <img
             src={marketplace.logoUrl}
-            className="object-cover w-12 h-12 md:w-8 md:h-8 rounded-full aspect-square"
+            className="absolute border-4 border-gray-900 object-cover rounded-full w-16 h-16 -top-28 md:w-28 md:h-28 md:-top-32"
           />
         </div>
         <div className="flex flex-col md:flex-row">

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -214,6 +214,10 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
   const { publicKey, connected } = useWallet()
   const [hasMore, setHasMore] = useState(true)
   const router = useRouter()
+  let hostname
+  if (typeof window !== 'undefined') {
+    hostname = window.location.hostname;
+ }
   const {
     data,
     loading: loadingNfts,
@@ -304,6 +308,12 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
           {marketplace.name}
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
+        <meta property="og:type" content="website" />
+        {hostname && (<meta property="og:site_name" content={hostname} />)}
+        <meta property="og:title" content={truncateAddress(router.query?.collection as string) + ' NFT Collection ' + ' | '+ marketplace.name} />
+        <meta property="og:image" content={marketplace.bannerUrl} />
+        <meta property="og:description" content={marketplace.description} />
+     
       </Head>
       <div className="relative w-full">
         <Link to="/" className="absolute top-6 left-6">

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -119,7 +119,7 @@ const GET_COLLECTION_INFO = gql`
 
 export async function getServerSideProps({ req, query }: NextPageContext) {
   const subdomain = req?.headers['x-holaplex-subdomain']
-
+  const host = req?.headers.host
   const {
     data: { marketplace, creator },
   } = await client.query<GetCollectionPage>({
@@ -184,6 +184,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
     props: {
       marketplace,
       creator,
+      host
     },
   }
 }
@@ -200,6 +201,7 @@ interface GetCollectionInfo {
 interface CollectionPageProps extends AppProps {
   marketplace: Marketplace
   creator: Creator
+  host: string
 }
 
 interface NftFilterForm {
@@ -210,14 +212,11 @@ interface NftFilterForm {
 const CollectionShow: NextPage<CollectionPageProps> = ({
   marketplace,
   creator,
+  host
 }) => {
   const { publicKey, connected } = useWallet()
   const [hasMore, setHasMore] = useState(true)
   const router = useRouter()
-  let hostname
-  if (typeof window !== 'undefined') {
-    hostname = window.location.hostname;
- }
   const {
     data,
     loading: loadingNfts,
@@ -309,7 +308,7 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {hostname && (<meta property="og:site_name" content={hostname} />)}
+        {host && (<meta property="og:site_name" content={host} />)}
         <meta property="og:title" content={truncateAddress(router.query?.collection as string) + ' NFT Collection ' + ' | '+ marketplace.name} />
         <meta property="og:image" content={marketplace.bannerUrl} />
         <meta property="og:description" content={marketplace.description} />

--- a/src/pages/collections/[collection].tsx
+++ b/src/pages/collections/[collection].tsx
@@ -184,7 +184,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
     props: {
       marketplace,
       creator,
-      host
+      host,
     },
   }
 }
@@ -212,7 +212,7 @@ interface NftFilterForm {
 const CollectionShow: NextPage<CollectionPageProps> = ({
   marketplace,
   creator,
-  host
+  host,
 }) => {
   const { publicKey, connected } = useWallet()
   const [hasMore, setHasMore] = useState(true)
@@ -308,11 +308,18 @@ const CollectionShow: NextPage<CollectionPageProps> = ({
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {host && (<meta property="og:site_name" content={host} />)}
-        <meta property="og:title" content={truncateAddress(router.query?.collection as string) + ' NFT Collection ' + ' | '+ marketplace.name} />
+        <meta property="og:site_name" content={host} />
+        <meta
+          property="og:title"
+          content={
+            truncateAddress(router.query?.collection as string) +
+            ' NFT Collection ' +
+            ' | ' +
+            marketplace.name
+          }
+        />
         <meta property="og:image" content={marketplace.bannerUrl} />
         <meta property="og:description" content={marketplace.description} />
-     
       </Head>
       <div className="relative w-full">
         <Link to="/" className="absolute top-6 left-6">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -215,7 +215,10 @@ interface NftFilterForm {
 const Home: NextPage<HomePageProps> = ({ marketplace }) => {
   const { publicKey, connected } = useWallet()
   const creators = map(prop('creatorAddress'))(marketplace.creators)
-
+  let hostname
+  if (typeof window !== 'undefined') {
+    hostname = window.location.hostname;
+ }
   const marketplaceQuery = useQuery<GetMarketplaceInfo>(GET_MARKETPLACE_INFO, {
     variables: {
       subdomain: marketplace.subdomain,
@@ -300,6 +303,11 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
       <Head>
         <title>{marketplace.name}</title>
         <link rel="icon" href={marketplace.logoUrl} />
+        <meta property="og:type" content="website" />
+        {hostname && (<meta property="og:site_name" content={hostname} />)}
+        <meta property="og:title" content={marketplace.name} />
+        <meta property="og:image" content={marketplace.bannerUrl} />
+        <meta property="og:description" content={marketplace.description} />
       </Head>
       <div className="relative w-full">
         <div className="absolute flex justify-end right-6 top-[28px]">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -125,7 +125,7 @@ const GET_MARKETPLACE_INFO = gql`
 
 export async function getServerSideProps({ req }: NextPageContext) {
   const subdomain = req?.headers['x-holaplex-subdomain'] || SUBDOMAIN
-
+  const host = req?.headers.host
   const response = await client.query<GetMarketplace>({
     fetchPolicy: 'no-cache',
     query: gql`
@@ -187,6 +187,7 @@ export async function getServerSideProps({ req }: NextPageContext) {
   return {
     props: {
       marketplace,
+      host
     },
   }
 }
@@ -205,6 +206,7 @@ interface GetCreatorPreviews {
 
 interface HomePageProps extends AppProps {
   marketplace: Marketplace
+  host: string
 }
 
 interface NftFilterForm {
@@ -212,13 +214,9 @@ interface NftFilterForm {
   preset: PresetNftFilter
 }
 
-const Home: NextPage<HomePageProps> = ({ marketplace }) => {
+const Home: NextPage<HomePageProps> = ({ marketplace, host }) => {
   const { publicKey, connected } = useWallet()
   const creators = map(prop('creatorAddress'))(marketplace.creators)
-  let hostname
-  if (typeof window !== 'undefined') {
-    hostname = window.location.hostname;
- }
   const marketplaceQuery = useQuery<GetMarketplaceInfo>(GET_MARKETPLACE_INFO, {
     variables: {
       subdomain: marketplace.subdomain,
@@ -304,7 +302,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace }) => {
         <title>{marketplace.name}</title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {hostname && (<meta property="og:site_name" content={hostname} />)}
+        {host && (<meta property="og:site_name" content={host} />)}
         <meta property="og:title" content={marketplace.name} />
         <meta property="og:image" content={marketplace.bannerUrl} />
         <meta property="og:description" content={marketplace.description} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -187,7 +187,7 @@ export async function getServerSideProps({ req }: NextPageContext) {
   return {
     props: {
       marketplace,
-      host
+      host,
     },
   }
 }
@@ -302,7 +302,7 @@ const Home: NextPage<HomePageProps> = ({ marketplace, host }) => {
         <title>{marketplace.name}</title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {host && (<meta property="og:site_name" content={host} />)}
+        <meta property="og:site_name" content={host} />)
         <meta property="og:title" content={marketplace.name} />
         <meta property="og:image" content={marketplace.bannerUrl} />
         <meta property="og:description" content={marketplace.description} />

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -198,7 +198,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
   return {
     props: {
       marketplace,
-      host
+      host,
     },
   }
 }
@@ -223,7 +223,6 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
   const router = useRouter()
   const cancelListingForm = useForm()
   const buyNowForm = useForm()
-
 
   const { data, loading, refetch } = useQuery<GetNftData>(GET_NFT, {
     variables: {
@@ -256,8 +255,8 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
   activities.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt))
 
   const buyNftTransaction = async () => {
-    if(!publicKey || !signTransaction){
-      login();
+    if (!publicKey || !signTransaction) {
+      login()
       return
     }
 
@@ -466,8 +465,8 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
   }
 
   const cancelListingTransaction = async () => {
-    if(!publicKey || !signTransaction){
-      login();
+    if (!publicKey || !signTransaction) {
+      login()
       return
     }
 
@@ -568,11 +567,13 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {host && (<meta property="og:site_name" content={host} />)}
-        <meta property="og:title" content={data?.nft.name + ' | '+ marketplace.name} />
+        <meta property="og:site_name" content={host} />
+        <meta
+          property="og:title"
+          content={`${data?.nft.name} | ${marketplace.name}`}
+        />
         <meta property="og:image" content={data?.nft.image} />
         <meta property="og:description" content={data?.nft.description} />
-       
       </Head>
       <div className="sticky top-0 z-10 flex items-center justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
         <Link to="/">
@@ -702,89 +703,86 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
                 </div>
               </div>
               <div className={cx('flex gap-4', { hidden: loading })}>
-                  <Routes>
-                    <Route
-                      path={`/nfts/${data?.nft.address}`}
-                      element={
-                        <>
-                          {!isOwner && !offer && (
-                            <Link
-                              to={`/nfts/${data?.nft.address}/offers/new`}
-                              className="flex-1 mt-6"
+                <Routes>
+                  <Route
+                    path={`/nfts/${data?.nft.address}`}
+                    element={
+                      <>
+                        {!isOwner && !offer && (
+                          <Link
+                            to={`/nfts/${data?.nft.address}/offers/new`}
+                            className="flex-1 mt-6"
+                          >
+                            <Button type={ButtonType.Secondary} block>
+                              Make Offer
+                            </Button>
+                          </Link>
+                        )}
+                        {isOwner && !listing && (
+                          <Link
+                            to={`/nfts/${data?.nft.address}/listings/new`}
+                            className="flex-1 mt-6"
+                          >
+                            <Button block>Sell NFT</Button>
+                          </Link>
+                        )}
+                        {listing && !isOwner && (
+                          <form
+                            className="flex-1 mt-6"
+                            onSubmit={buyNowForm.handleSubmit(
+                              buyNftTransaction
+                            )}
+                          >
+                            <Button
+                              loading={buyNowForm.formState.isSubmitting}
+                              htmlType="submit"
+                              block
                             >
-                              <Button type={ButtonType.Secondary} block>
-                                Make Offer
-                              </Button>
-                            </Link>
-                          )}
-                          {isOwner && !listing && (
-                            <Link
-                              to={`/nfts/${data?.nft.address}/listings/new`}
-                              className="flex-1 mt-6"
+                              Buy Now
+                            </Button>
+                          </form>
+                        )}
+                        {listing && isOwner && (
+                          <form
+                            className="flex-1 mt-6"
+                            onSubmit={cancelListingForm.handleSubmit(
+                              cancelListingTransaction
+                            )}
+                          >
+                            <Button
+                              block
+                              loading={cancelListingForm.formState.isSubmitting}
+                              htmlType="submit"
+                              type={ButtonType.Secondary}
                             >
-                              <Button block>Sell NFT</Button>
-                            </Link>
-                          )}
-                          {listing && !isOwner && (
-                            <form
-                              className="flex-1 mt-6"
-                              onSubmit={buyNowForm.handleSubmit(
-                                buyNftTransaction
-                              )}
-                            >
-                              <Button
-                                loading={buyNowForm.formState.isSubmitting}
-                                htmlType="submit"
-                                block
-                              >
-                                Buy Now
-                              </Button>
-                            </form>
-                          )}
-                          {listing && isOwner && (
-                            <form
-                              className="flex-1 mt-6"
-                              onSubmit={cancelListingForm.handleSubmit(
-                                cancelListingTransaction
-                              )}
-                            >
-                              <Button
-                                block
-                                loading={
-                                  cancelListingForm.formState.isSubmitting
-                                }
-                                htmlType="submit"
-                                type={ButtonType.Secondary}
-                              >
-                                Cancel Listing
-                              </Button>
-                            </form>
-                          )}
-                        </>
-                      }
-                    />
-                    <Route
-                      path={`/nfts/${data?.nft.address}/offers/new`}
-                      element={
-                        <OfferPage
-                          nft={data?.nft}
-                          marketplace={marketplace}
-                          refetch={refetch}
-                        />
-                      }
-                    />
-                    <Route
-                      path={`/nfts/${data?.nft.address}/listings/new`}
-                      element={
-                        <SellNftPage
-                          nft={data?.nft}
-                          marketplace={marketplace}
-                          refetch={refetch}
-                        />
-                      }
-                    />
-                  </Routes>
-                
+                              Cancel Listing
+                            </Button>
+                          </form>
+                        )}
+                      </>
+                    }
+                  />
+                  <Route
+                    path={`/nfts/${data?.nft.address}/offers/new`}
+                    element={
+                      <OfferPage
+                        nft={data?.nft}
+                        marketplace={marketplace}
+                        refetch={refetch}
+                      />
+                    }
+                  />
+                  <Route
+                    path={`/nfts/${data?.nft.address}/listings/new`}
+                    element={
+                      <SellNftPage
+                        nft={data?.nft}
+                        marketplace={marketplace}
+                        refetch={refetch}
+                      />
+                    }
+                  />
+                </Routes>
               </div>
             </div>
             <div className="grid grid-cols-2 gap-6 mt-8">

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -131,7 +131,7 @@ const GET_NFT = gql`
 
 export async function getServerSideProps({ req, query }: NextPageContext) {
   const subdomain = req?.headers['x-holaplex-subdomain']
-
+  const host = req?.headers.host
   const {
     data: { marketplace, nft },
   } = await client.query<GetNftPage>({
@@ -198,6 +198,7 @@ export async function getServerSideProps({ req, query }: NextPageContext) {
   return {
     props: {
       marketplace,
+      host
     },
   }
 }
@@ -209,22 +210,20 @@ interface GetNftPage {
 
 interface NftPageProps extends AppProps {
   marketplace: Marketplace
+  host: string
 }
 
 interface GetNftData {
   nft: Nft
 }
 
-const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
+const NftShow: NextPage<NftPageProps> = ({ marketplace, host }) => {
   const { publicKey, signTransaction, connected, connecting } = useWallet()
   const { connection } = useConnection()
   const router = useRouter()
   const cancelListingForm = useForm()
   const buyNowForm = useForm()
-  let hostname
-  if (typeof window !== 'undefined') {
-    hostname = window.location.hostname;
- }
+
 
   const { data, loading, refetch } = useQuery<GetNftData>(GET_NFT, {
     variables: {
@@ -569,22 +568,11 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
         <meta property="og:type" content="website" />
-        {hostname && (<meta property="og:site_name" content={hostname} />)}
-        {data?.nft ? (
-          <>
-            <meta property="og:title" content={data?.nft.name + ' | '+ marketplace.name} />
-            <meta property="og:image" content={data?.nft.image} />
-            <meta property="og:description" content={data?.nft.description} />
-          </>
-        ):
-        (
-          <>
-            <meta property="og:title" content={truncateAddress(router.query?.address as string) + ' NFT' + ' | '+ marketplace.name} />
-            <meta property="og:image" content={marketplace.bannerUrl} />
-            <meta property="og:description" content={marketplace.description} />
-          </>
-        )
-        }
+        {host && (<meta property="og:site_name" content={host} />)}
+        <meta property="og:title" content={data?.nft.name + ' | '+ marketplace.name} />
+        <meta property="og:image" content={data?.nft.image} />
+        <meta property="og:description" content={data?.nft.description} />
+       
       </Head>
       <div className="sticky top-0 z-10 flex items-center justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
         <Link to="/">

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -221,6 +221,10 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
   const router = useRouter()
   const cancelListingForm = useForm()
   const buyNowForm = useForm()
+  let hostname
+  if (typeof window !== 'undefined') {
+    hostname = window.location.hostname;
+ }
 
   const { data, loading, refetch } = useQuery<GetNftData>(GET_NFT, {
     variables: {
@@ -564,6 +568,23 @@ const NftShow: NextPage<NftPageProps> = ({ marketplace }) => {
           {marketplace.name}
         </title>
         <link rel="icon" href={marketplace.logoUrl} />
+        <meta property="og:type" content="website" />
+        {hostname && (<meta property="og:site_name" content={hostname} />)}
+        {data?.nft ? (
+          <>
+            <meta property="og:title" content={data?.nft.name + ' | '+ marketplace.name} />
+            <meta property="og:image" content={data?.nft.image} />
+            <meta property="og:description" content={data?.nft.description} />
+          </>
+        ):
+        (
+          <>
+            <meta property="og:title" content={truncateAddress(router.query?.address as string) + ' NFT' + ' | '+ marketplace.name} />
+            <meta property="og:image" content={marketplace.bannerUrl} />
+            <meta property="og:description" content={marketplace.description} />
+          </>
+        )
+        }
       </Head>
       <div className="sticky top-0 z-10 flex items-center justify-between p-6 text-white bg-gray-900/80 backdrop-blur-md grow">
         <Link to="/">


### PR DESCRIPTION
Completes #133 

For pretty social sharing, we needed to add og tags in the headers of these pages - Nft Page, Collection Page, Home Page.

(Note: For the collection page, right now marketplace banner image is added as og tag. But if we could fetch the preview image in the fetch nft api, then we can add this preview image as well.)

This is how it will look like: 

<img width="560" alt="Screenshot 2022-03-31 at 8 45 45 AM" src="https://user-images.githubusercontent.com/1254443/160970113-6fe5e9e4-b2d6-48cb-8321-f95c789c39cf.png">

(Instead of local-ogp....com it will showing marketplace site address)