### PR TITLE
Update deprecated functions: [confirmTransaction & getRecentBlockhash]

### DIFF
--- a/src/modules/marketplace/client.ts
+++ b/src/modules/marketplace/client.ts
@@ -108,7 +108,7 @@ class MarketplaceClient {
     transaction.add(setStorefrontV2Instructions)
     transaction.feePayer = publicKey
     transaction.recentBlockhash = (
-      await connection.getRecentBlockhash()
+      await connection.getLatestBlockhash()
     ).blockhash
 
     const signedTransaction = await wallet.signTransaction!(transaction)

--- a/src/pages/nfts/[address].tsx
+++ b/src/pages/nfts/[address].tsx
@@ -7,6 +7,7 @@ import {
   SYSVAR_INSTRUCTIONS_PUBKEY,
   Transaction,
   TransactionInstruction,
+  BlockheightBasedTransactionConfirmationStrategy,
 } from '@solana/web3.js'
 import { useRouter } from 'next/router'
 import { NextPage, NextPageContext } from 'next'
@@ -407,7 +408,7 @@ const NftShow: NextPage<NftPageProps> = ({
       )
       .add(printPurchaseReceiptInstruction)
 
-    txt.recentBlockhash = (await connection.getRecentBlockhash()).blockhash
+    txt.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
     txt.feePayer = publicKey
 
     let signed: Transaction | undefined = undefined
@@ -426,7 +427,13 @@ const NftShow: NextPage<NftPageProps> = ({
 
       signature = await connection.sendRawTransaction(signed.serialize())
 
-      await connection.confirmTransaction(signature, 'confirmed')
+      const currentBlockHeight = await connection.getBlockHeight()
+      let strategy: BlockheightBasedTransactionConfirmationStrategy = {
+        signature: signature,
+        blockhash: txt.recentBlockhash,
+        lastValidBlockHeight: currentBlockHeight + 1000,
+      }
+      await connection.confirmTransaction(strategy)
 
       toast.success('The transaction was confirmed.')
 
@@ -498,7 +505,7 @@ const NftShow: NextPage<NftPageProps> = ({
 
     txt.add(cancelInstruction).add(cancelListingReceiptInstruction)
 
-    txt.recentBlockhash = (await connection.getRecentBlockhash()).blockhash
+    txt.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
     txt.feePayer = publicKey
 
     let signed: Transaction | undefined = undefined
@@ -517,7 +524,13 @@ const NftShow: NextPage<NftPageProps> = ({
 
       signature = await connection.sendRawTransaction(signed.serialize())
 
-      await connection.confirmTransaction(signature, 'confirmed')
+      const currentBlockHeight = await connection.getBlockHeight()
+      let strategy: BlockheightBasedTransactionConfirmationStrategy = {
+        signature: signature,
+        blockhash: txt.recentBlockhash,
+        lastValidBlockHeight: currentBlockHeight + 1000,
+      }
+      await connection.confirmTransaction(strategy)
 
       toast.success('The transaction was confirmed.')
 

--- a/src/pages/nfts/[address]/listings/new.tsx
+++ b/src/pages/nfts/[address]/listings/new.tsx
@@ -297,7 +297,7 @@ const ListingNew = ({ nft, marketplace }: SellNftProps) => {
 
     txt.add(sellInstruction).add(printListingReceiptInstruction)
 
-    txt.recentBlockhash = (await connection.getRecentBlockhash()).blockhash
+    txt.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
     txt.feePayer = publicKey
 
     let signed: Transaction | undefined = undefined
@@ -328,7 +328,7 @@ const ListingNew = ({ nft, marketplace }: SellNftProps) => {
 
   return (
     <form
-      className="text-left grow mt-6"
+      className="mt-6 text-left grow"
       onSubmit={handleSubmit(sellNftTransaction)}
     >
       <h3 className="mb-6 text-xl font-bold md:text-2xl">Sell this Nft</h3>


### PR DESCRIPTION
Both `connection.getRecentBlockhash` and `connection.confirmTransaction` have been deprecated in the way we use them. I've updated the functions as needed. 