### PR TITLE
Use new `market` sub-domain

### DIFF
--- a/src/modules/ipfs/client.ts
+++ b/src/modules/ipfs/client.ts
@@ -14,7 +14,7 @@ const ipfsSDK = {
     const body = new FormData()
     body.append(file.name, file, file.name)
     try {
-      const resp = await fetch('https://www.holaplex.com/api/ipfs/upload', {
+      const resp = await fetch('https://market.holaplex.com/api/ipfs/upload', {
         method: 'POST',
         body,
       })


### PR DESCRIPTION
`www` no longer serves market assets/api, use new `market` subdomain.